### PR TITLE
Fix issues #83-#88: fields, wantedFacets, cluster, list, mapping, feed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -311,19 +311,6 @@ npm run test:watch
 npm run lint
 ```
 
-## Environment Variables
-
-Used for running tests and examples:
-
-| Variable | Description |
-|---|---|
-| `AFPNEWS_BASE_URL` | API base URL (default: `https://afp-apicore-prod.afp.com`) |
-| `AFPNEWS_API_KEY` | API key for anonymous auth |
-| `AFPNEWS_CLIENT_ID` | OAuth client ID |
-| `AFPNEWS_CLIENT_SECRET` | OAuth client secret |
-| `AFPNEWS_USERNAME` | User credentials |
-| `AFPNEWS_PASSWORD` | User credentials |
-
 ## Author
 
 [Jules Bonnard](https://github.com/julesbonnard)

--- a/Readme.md
+++ b/Readme.md
@@ -1,102 +1,344 @@
 # AfpNews API
 
-This project is aimed to help javascript developers use the AFP Core API.
+[![npm version](https://img.shields.io/npm/v/afpnews-api.svg)](https://www.npmjs.com/package/afpnews-api)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
 
-It provides authentication, searching for documents function, and online news product.
+A TypeScript client library for the [AFP Core API](https://afp-apicore-prod.afp.com). Provides authentication, document search, notification management, saved filters, and social story retrieval for both Node.js and browser environments.
 
-## Getting Started
+## Installation
 
-This package is available both for NodeJS and browsers. That's why two versions are available on the `./dist` directory.
+### Node.js
 
-### Prerequisites
-
-You'll need an API key and credentials to retrieve all content from the API.
-
-### Installing
-
-#### Node
-
-`npm install --save afpnews-api`
-
-```js
-const { ApiCore } = require('afpnews-api')
-// OR using import
-import { ApiCore } from 'afpnews-api'
+```bash
+npm install afpnews-api
 ```
 
-#### Browser
+```js
+import { ApiCore } from 'afpnews-api'
+// or CommonJS
+const { ApiCore } = require('afpnews-api')
+```
+
+### Browser (UMD)
 
 ```html
-<script src="./dist/bundles/apicore.min.js"></script>
+<script src="https://unpkg.com/afpnews-api/dist/bundles/apicore.min.js"></script>
 ```
 
-### Let's start using it
+### Browser (ESM)
 
 ```js
-// Initialize the API
-const apicore = new ApiCore({ clientId, clientSecret })
-
-// Authenticate
-await apicore.authenticate({ username, password })
-
-// Get token changed
-apicore.on('tokenChanged', token => console.log(token))
-
-// Search for latest documents
-const { documents } = await apicore.search()
-
-// Or using a generator to crawl multiple pages
-for await (const doc of apicore.searchAll()) {
-  console.log(doc)
-}
-
-// Get a specific document
-const document = await apicore.get(uno)
-
-// Look for similar documents
-const { documents } = await apicore.mlt(uno)
-
-// Display the most used slugs
-const { keywords } = await apicore.list('slug')
+import { ApiCore } from 'https://cdn.jsdelivr.net/npm/afpnews-api/dist/bundles/apicore.min.mjs'
 ```
 
-### Query parser
+## Prerequisites
 
-The above request use default parameters stored in ./src/default-search-params.js
+You need an API key or client credentials (client ID + secret) to connect. For user-authenticated requests, you also need a username and password.
 
-You can pass your own parameters to the search function, that will overide the defaults.
+## Quick Start
 
-The query parameter can be used to look precisely for a field (`title:Macron`) and may include logical parameters (`Macron OR Merkel`, `Macron AND NOT Merkel`, `(title:Macron OR title:Merkel) AND country:fra`).
+```js
+import { ApiCore } from 'afpnews-api'
+
+// Initialize with client credentials
+const afp = new ApiCore({ clientId: 'your-id', clientSecret: 'your-secret' })
+
+// Or with an API key
+const afp = new ApiCore({ apiKey: 'your-api-key' })
+
+// Optionally override the base URL
+const afp = new ApiCore({ clientId: 'your-id', clientSecret: 'your-secret', baseUrl: 'https://custom-api.afp.com' })
+```
+
+## Authentication
+
+```js
+// Anonymous authentication (uses API key or client credentials)
+await afp.authenticate()
+
+// Authenticate with user credentials
+await afp.authenticate({ username: 'user', password: 'pass' })
+
+// Listen for token changes
+afp.on('tokenChanged', (token) => {
+  console.log(token)
+  // { accessToken, refreshToken, tokenExpires, authType }
+})
+
+// Token is automatically refreshed when expired
+```
+
+## Searching Documents
+
+### Basic Search
+
+```js
+const { count, documents } = await afp.search()
+```
+
+### Search with Parameters
+
+```js
+const { count, documents } = await afp.search({
+  query: 'Macron',
+  langs: ['fr', 'en'],
+  dateFrom: '2024-01-01',
+  dateTo: '2024-12-31',
+  size: 20,
+  sortField: 'published',
+  sortOrder: 'desc',
+  tz: 'Europe/Paris',
+  dateGap: '+1HOUR',
+  startAt: 0,
+  wantCluster: true,
+  wantedFacets: [{ size: 10, minDocCount: 1 }],
+  sort: [{ sortField: 'published', sortOrder: 'desc' }]
+})
+```
+
+### Additional Filtering Parameters
+
+Any extra key-value pair is passed as an additional query filter:
+
+```js
+const { documents } = await afp.search({
+  query: 'climate',
+  country: 'fra',
+  urgency: 3,
+  slug: ['politics', 'economy']
+})
+```
+
+You can also use include/exclude syntax:
+
+```js
+const { documents } = await afp.search({
+  country: { in: ['fra', 'deu'] },
+  product: { exclude: ['photo'] }
+})
+```
+
+### Specify Response Fields
+
+Pass an array of field names to limit the returned fields:
+
+```js
+const { documents } = await afp.search({}, ['uno', 'title', 'published'])
+```
+
+### Paginated Search
+
+Use `searchAll()` to iterate over large result sets automatically:
+
+```js
+for await (const doc of afp.searchAll({ size: 5000, query: 'climate' })) {
+  console.log(doc.uno)
+}
+```
+
+### Search with Saved Filter
+
+```js
+const { count, documents } = await afp.searchWithFilter('my-filter', {
+  startat: 0,
+  size: 50
+})
+```
+
+### Cluster Search
+
+```js
+const clusters = await afp.cluster({ query: 'elections' })
+```
+
+## Query Syntax
+
+The `query` parameter supports a boolean query DSL:
+
+| Syntax | Example |
+|---|---|
+| Simple term | `Macron` |
+| Field search | `title:Macron` |
+| AND | `Macron AND Merkel` |
+| OR | `title:Macron OR title:Merkel` |
+| NOT | `Macron AND NOT country:fra` |
+| Parentheses | `(title:Macron OR title:Merkel) AND country:fra` |
+| Quoted phrase | `title:"climate change"` |
+| Implicit AND | `Macron France` (space-separated terms) |
+
+## Retrieving a Single Document
+
+```js
+const document = await afp.get('AFP-UNIQUE-ID')
+```
+
+## More Like This
+
+Find documents similar to a given one:
+
+```js
+const { count, documents } = await afp.mlt('AFP-UNIQUE-ID', 'en', 10)
+```
+
+## Latest Documents
+
+Get the most recent documents:
+
+```js
+const { count, documents } = await afp.latest({ lang: 'fr', tz: 'Europe/Paris' })
+```
+
+## Listing Facet Values
+
+Retrieve the most used values for a specific facet:
+
+```js
+const { count, keywords } = await afp.list('slug')
+
+// With custom search scope and minimum document count
+const { keywords } = await afp.list('country', { dateFrom: 'now-7d', langs: ['en'] }, 5)
+```
+
+## Field Mapping
+
+Get the API field mapping:
+
+```js
+const mapping = await afp.mapping()
+
+// With a specific language
+const mapping = await afp.mapping('fr')
+```
+
+## RSS/ATOM Feed
+
+Retrieve an RSS/ATOM feed based on a saved filter:
+
+```js
+const xmlContent = await afp.feed('my-filter', { size: 20 })
+```
+
+## Notification Center
+
+Subscribe to real-time document notifications via mail, REST, SQS, or JMS services.
+
+```js
+const nc = afp.notificationCenter
+
+// Register a REST service
+const serviceId = await nc.registerService({
+  name: 'my-webhook',
+  type: 'rest',
+  datas: { href: 'https://example.com/webhook' }
+})
+
+// Add a subscription
+const subId = await nc.addSubscription('breaking-news', 'my-webhook', {
+  query: 'urgency:1',
+  langs: ['en']
+})
+
+// List services and subscriptions
+const services = await nc.listServices()
+const subscriptions = await nc.listSubscriptions()
+const subs = await nc.subscriptionsInService('my-webhook')
+
+// Cleanup
+await nc.deleteSubscription('my-webhook', 'breaking-news')
+await nc.removeSubscriptionsFromService('my-webhook', ['sub1', 'sub2'])
+await nc.deleteService('my-webhook')
+```
+
+## Filter Center
+
+Manage saved search filters.
+
+```js
+const fc = afp.filterCenter
+
+// Create a filter
+await fc.add('breaking-politics', { query: 'urgency:1', country: 'fra' })
+
+// Update a filter
+await fc.update('breaking-politics', { query: 'urgency:1 OR urgency:2' })
+
+// Get a specific filter
+const filter = await fc.get('breaking-politics')
+
+// List all filters
+const allFilters = await fc.all()
+
+// Delete a filter
+await fc.delete('breaking-politics')
+```
+
+## Social Stories
+
+Retrieve the embeddable HTML for a social story document:
+
+```js
+const html = afp.getStoryHtml(doc)
+```
+
+## Search Parameters Reference
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `query` | `string` | — | Boolean query string (see Query Syntax) |
+| `langs` | `string[]` | — | Filter by language codes |
+| `dateFrom` | `string` | `'1980-01-01'` | Start date (ISO date or relative like `'now-7d'`) |
+| `dateTo` | `string` | `'now'` | End date |
+| `size` | `number` | `10` | Number of results (max 1000 per request) |
+| `sortField` | `string` | `'published'` | Field to sort by |
+| `sortOrder` | `'asc' \| 'desc'` | `'desc'` | Sort direction |
+| `startAt` | `number` | — | Offset for pagination |
+| `tz` | `string` | — | Timezone (e.g. `'Europe/Paris'`) |
+| `dateGap` | `string` | — | Date gap for facet ranges (e.g. `'+1HOUR'`, `'+1DAY'`) |
+| `wantCluster` | `boolean` | — | Include cluster information |
+| `wantedFacets` | `FacetConfig[]` | — | Facets configuration `[{ size, minDocCount }]` |
+| `sort` | `SortEntry[]` | — | Multi-field sort `[{ sortField, sortOrder }]` |
+
+Any additional key-value pairs are treated as field filters.
 
 ## Development
 
-Clone the repository, then `npm install`
+```bash
+# Install dependencies
+npm install
 
-Build and minify your work for browsers and node with `npm run build`
+# Build (clean + parser + types + ESM/CJS/bundles)
+npm run build
 
-## Running the tests
+# Development with auto-rebuild
+npm run build:watch
 
-Just `npm test` to execute all tests in `./tests`
+# Run tests
+npm test
 
-You will need some environment variables in a .env file : 
+# Run tests in watch mode
+npm run test:watch
 
+# Lint
+npm run lint
 ```
-AFPNEWS_BASE_URL=
-AFPNEWS_API_KEY=
-AFPNEWS_CLIENT_ID=
-AFPNEWS_CLIENT_SECRET=
-AFPNEWS_USERNAME=
-AFPNEWS_PASSWORD=
-```
 
-## Built With
+## Environment Variables
 
-* [TypeScript](https://www.typescriptlang.org/) - Typescript
+Used for running tests and examples:
 
-## Authors
+| Variable | Description |
+|---|---|
+| `AFPNEWS_BASE_URL` | API base URL (default: `https://afp-apicore-prod.afp.com`) |
+| `AFPNEWS_API_KEY` | API key for anonymous auth |
+| `AFPNEWS_CLIENT_ID` | OAuth client ID |
+| `AFPNEWS_CLIENT_SECRET` | OAuth client secret |
+| `AFPNEWS_USERNAME` | User credentials |
+| `AFPNEWS_PASSWORD` | User credentials |
 
-* [Jules Bonnard](https://github.com/julesbonnard) - *Initial work*
+## Author
+
+[Jules Bonnard](https://github.com/julesbonnard)
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+MIT - see [LICENSE.md](LICENSE.md)

--- a/Readme.md
+++ b/Readme.md
@@ -68,6 +68,14 @@ afp.on('tokenChanged', (token) => {
 // Token is automatically refreshed when expired
 ```
 
+## Latest Documents
+
+Get the most recent documents:
+
+```js
+const { count, documents } = await afp.latest({ lang: 'fr', tz: 'Europe/Paris' })
+```
+
 ## Searching Documents
 
 ### Basic Search
@@ -90,8 +98,7 @@ const { count, documents } = await afp.search({
   tz: 'Europe/Paris',
   dateGap: '+1HOUR',
   startAt: 0,
-  wantCluster: true,
-  wantedFacets: [{ size: 10, minDocCount: 1 }],
+  wantedFacets: { slug: { size: 10, minDocCount: 1 }, country: { size: 5, minDocCount: 1 } },
   sort: [{ sortField: 'published', sortOrder: 'desc' }]
 })
 ```
@@ -136,21 +143,6 @@ for await (const doc of afp.searchAll({ size: 5000, query: 'climate' })) {
 }
 ```
 
-### Search with Saved Filter
-
-```js
-const { count, documents } = await afp.searchWithFilter('my-filter', {
-  startat: 0,
-  size: 50
-})
-```
-
-### Cluster Search
-
-```js
-const clusters = await afp.cluster({ query: 'elections' })
-```
-
 ## Query Syntax
 
 The `query` parameter supports a boolean query DSL:
@@ -169,7 +161,7 @@ The `query` parameter supports a boolean query DSL:
 ## Retrieving a Single Document
 
 ```js
-const document = await afp.get('AFP-UNIQUE-ID')
+const document = await afp.get('uno')
 ```
 
 ## More Like This
@@ -177,15 +169,7 @@ const document = await afp.get('AFP-UNIQUE-ID')
 Find documents similar to a given one:
 
 ```js
-const { count, documents } = await afp.mlt('AFP-UNIQUE-ID', 'en', 10)
-```
-
-## Latest Documents
-
-Get the most recent documents:
-
-```js
-const { count, documents } = await afp.latest({ lang: 'fr', tz: 'Europe/Paris' })
+const { count, documents } = await afp.mlt('uno', 'en', 10)
 ```
 
 ## Listing Facet Values
@@ -204,10 +188,39 @@ const { keywords } = await afp.list('country', { dateFrom: 'now-7d', langs: ['en
 Get the API field mapping:
 
 ```js
-const mapping = await afp.mapping()
+const mapping = await afp.mapping('en')
+```
 
-// With a specific language
-const mapping = await afp.mapping('fr')
+## Filter Center
+
+Manage saved search filters.
+
+```js
+const fc = afp.filterCenter
+
+// Create a filter
+await fc.add('breaking-politics', { query: 'urgency:1', country: 'fra' })
+
+// Update a filter
+await fc.update('breaking-politics', { query: 'urgency:1 OR urgency:2' })
+
+// Get a specific filter
+const filter = await fc.get('breaking-politics')
+
+// List all filters
+const allFilters = await fc.all()
+
+// Delete a filter
+await fc.delete('breaking-politics')
+```
+
+### Search with Saved Filter
+
+```js
+const { count, documents } = await afp.searchWithFilter('my-filter', {
+  startat: 0,
+  size: 50
+})
 ```
 
 ## RSS/ATOM Feed
@@ -249,29 +262,6 @@ await nc.removeSubscriptionsFromService('my-webhook', ['sub1', 'sub2'])
 await nc.deleteService('my-webhook')
 ```
 
-## Filter Center
-
-Manage saved search filters.
-
-```js
-const fc = afp.filterCenter
-
-// Create a filter
-await fc.add('breaking-politics', { query: 'urgency:1', country: 'fra' })
-
-// Update a filter
-await fc.update('breaking-politics', { query: 'urgency:1 OR urgency:2' })
-
-// Get a specific filter
-const filter = await fc.get('breaking-politics')
-
-// List all filters
-const allFilters = await fc.all()
-
-// Delete a filter
-await fc.delete('breaking-politics')
-```
-
 ## Social Stories
 
 Retrieve the embeddable HTML for a social story document:
@@ -294,8 +284,7 @@ const html = afp.getStoryHtml(doc)
 | `startAt` | `number` | — | Offset for pagination |
 | `tz` | `string` | — | Timezone (e.g. `'Europe/Paris'`) |
 | `dateGap` | `string` | — | Date gap for facet ranges (e.g. `'+1HOUR'`, `'+1DAY'`) |
-| `wantCluster` | `boolean` | — | Include cluster information |
-| `wantedFacets` | `FacetConfig[]` | — | Facets configuration `[{ size, minDocCount }]` |
+| `wantedFacets` | `WantedFacets` | — | Facets configuration `{ facetName: { size, minDocCount }, empty?: boolean }` |
 | `sort` | `SortEntry[]` | — | Multi-field sort `[{ sortField, sortOrder }]` |
 
 Any additional key-value pairs are treated as field filters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afpnews-api",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Node helper functions to authenticate and fetch AFP Core API",
   "main": "dist/cjs/index.js",
   "type": "commonjs",

--- a/src/api/docs.ts
+++ b/src/api/docs.ts
@@ -22,7 +22,7 @@ const searchResponse = z.object({
 const listResponse = z.object({
   response: z.object({
     topics: z.object({
-      name: z.string(),
+      name: z.string().nullable().optional(),
       count: z.number()
     }).array().default([]),
     numFound: z.number().default(0)
@@ -219,39 +219,24 @@ export class Docs extends Auth {
 
   /**
    * Get the API field mapping
-   * @param lang - Optional language for the mapping
+   * @param lang - The language for the mapping
    * @returns The mapping object
    */
-  public async mapping (lang?: string) {
+  public async mapping (lang: string) {
     await this.authenticate()
-
-    const params: { wt: string; lang?: string } = { wt: 'json' }
-    if (lang) params.lang = lang
 
     const data = await get(`${this.baseUrl}/v1/api/mapping`, {
       headers: this.authorizationBearerHeaders,
-      params
+      params: { wt: 'json', lang }
     })
 
-    return data
-  }
+    const { response: { mapping } } = z.object({
+      response: z.object({
+        mapping: z.unknown()
+      })
+    }).parse(data)
 
-  /**
-   * Cluster search results
-   * @param params - An object containing the search parameters
-   * @param fields - An array of fields to include in the response
-   * @returns The cluster results
-   */
-  public async cluster (params: SearchQueryParams = {}, fields: string[] = []) {
-    const body = this.prepareRequest(params, fields)
-
-    await this.authenticate()
-    const data = await post(`${this.baseUrl}/v1/api/cluster`, body, {
-      headers: this.authorizationBearerHeaders,
-      params: { wt: 'json' }
-    })
-
-    return data
+    return mapping
   }
 
   /**
@@ -293,9 +278,10 @@ export class Docs extends Auth {
       headers: this.authorizationBearerHeaders,
       params: {
         filter,
+        wt: 'xml',
         ...options
       }
-    }, 'text')
+    }, 'text', 'application/rss+xml')
 
     return data
   }

--- a/src/api/docs.ts
+++ b/src/api/docs.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { Auth } from './auth'
 import { Story } from './story'
 import { NotificationCenter } from './notification'
+import { FilterCenter } from './filter'
 
 const docParser = z.object({
   published: z.string()
@@ -48,6 +49,12 @@ export class Docs extends Auth {
       sortOrder,
       langs,
       query,
+      startAt,
+      tz,
+      dateGap,
+      wantCluster,
+      wantedFacets,
+      sort,
       ...rest
     } = Object.assign({}, defaultSearchParams, params)
 
@@ -57,6 +64,12 @@ export class Docs extends Auth {
       .setSort(sortField, sortOrder)
       .setLangs(langs)
       .setQuery(query)
+      .setStartAt(startAt)
+      .setTz(tz)
+      .setDateGap(dateGap)
+      .setWantCluster(wantCluster)
+      .setWantedFacets(wantedFacets)
+      .setMultiSort(sort)
       .addAdditionalParams(rest)
       .build()
   }
@@ -72,7 +85,8 @@ export class Docs extends Auth {
 
     await this.authenticate()
     const data = await post(`${this.baseUrl}/v1/api/search`, body, {
-      headers: this.authorizationBearerHeaders
+      headers: this.authorizationBearerHeaders,
+      params: { wt: 'json' }
     })
 
     const { response: { docs: documents, numFound: count } } = searchResponse.parse(data)
@@ -116,7 +130,8 @@ export class Docs extends Auth {
     await this.authenticate()
 
     const data = await get(`${this.baseUrl}/v1/api/get/${uno}`, {
-      headers: this.authorizationBearerHeaders
+      headers: this.authorizationBearerHeaders,
+      params: { wt: 'json' }
     })
     const { response: { docs }} = getResponse.parse(data)
     return docs[0]
@@ -137,7 +152,8 @@ export class Docs extends Auth {
       params: {
         uno,
         lang,
-        size
+        size,
+        wt: 'json'
       }
     })
 
@@ -164,7 +180,8 @@ export class Docs extends Auth {
     const data = await post(`${this.baseUrl}/v1/api/list/${facet}`, body, {
       headers: this.authorizationBearerHeaders,
       params: {
-        minDocCount
+        minDocCount,
+        wt: 'json'
       }
     })
 
@@ -174,6 +191,113 @@ export class Docs extends Auth {
       count,
       keywords
     }
+  }
+
+  /**
+   * Get the latest documents
+   * @param params - Optional query params: lang, tz, tr
+   * @returns An object containing the documents and their count
+   */
+  public async latest (params: { lang?: string; tz?: string; tr?: string } = {}) {
+    await this.authenticate()
+
+    const data = await get(`${this.baseUrl}/v1/api/latest`, {
+      headers: this.authorizationBearerHeaders,
+      params: {
+        ...params,
+        wt: 'json'
+      }
+    })
+
+    const { response: { docs: documents, numFound: count } } = searchResponse.parse(data)
+
+    return {
+      count,
+      documents
+    }
+  }
+
+  /**
+   * Get the API field mapping
+   * @param lang - Optional language for the mapping
+   * @returns The mapping object
+   */
+  public async mapping (lang?: string) {
+    await this.authenticate()
+
+    const params: { wt: string; lang?: string } = { wt: 'json' }
+    if (lang) params.lang = lang
+
+    const data = await get(`${this.baseUrl}/v1/api/mapping`, {
+      headers: this.authorizationBearerHeaders,
+      params
+    })
+
+    return data
+  }
+
+  /**
+   * Cluster search results
+   * @param params - An object containing the search parameters
+   * @param fields - An array of fields to include in the response
+   * @returns The cluster results
+   */
+  public async cluster (params: SearchQueryParams = {}, fields: string[] = []) {
+    const body = this.prepareRequest(params, fields)
+
+    await this.authenticate()
+    const data = await post(`${this.baseUrl}/v1/api/cluster`, body, {
+      headers: this.authorizationBearerHeaders,
+      params: { wt: 'json' }
+    })
+
+    return data
+  }
+
+  /**
+   * Search documents using a saved filter
+   * @param filter - The filter name
+   * @param options - Optional startat and size parameters
+   * @returns An object containing the documents and their count
+   */
+  public async searchWithFilter (filter: string, options: { startat?: number; size?: number } = {}) {
+    await this.authenticate()
+
+    const data = await get(`${this.baseUrl}/v1/api/search_with_filter`, {
+      headers: this.authorizationBearerHeaders,
+      params: {
+        filter,
+        ...options,
+        wt: 'json'
+      }
+    })
+
+    const { response: { docs: documents, numFound: count } } = searchResponse.parse(data)
+
+    return {
+      count,
+      documents
+    }
+  }
+
+  /**
+   * Get an RSS/ATOM feed based on a saved filter
+   * @param filter - The filter name
+   * @param options - Optional startat, size, role and wt parameters
+   * @returns The feed content as text
+   */
+  public async feed (filter: string, options: { startat?: number; size?: number; role?: string; wt?: string } = {}) {
+    await this.authenticate()
+
+    const data = await get(`${this.baseUrl}/v1/user/feed`, {
+      headers: this.authorizationBearerHeaders,
+      params: {
+        filter,
+        ...options
+      }
+    }, 'text')
+
+    return data
   }
 
   /**
@@ -191,5 +315,13 @@ export class Docs extends Auth {
    */
   get notificationCenter () {
     return NotificationCenter.call(this)
+  }
+
+  /**
+   * Access the filter center to manage saved filters
+   * @returns The filter center
+   */
+  get filterCenter () {
+    return FilterCenter.call(this)
   }
 }

--- a/src/api/filter.ts
+++ b/src/api/filter.ts
@@ -1,0 +1,102 @@
+import { type ApiCore } from '..'
+import { SearchQueryParams } from '../types'
+import { get, post } from '../utils/request'
+
+export function FilterCenter (this: ApiCore) {
+  const baseFilterUrl = `${this.baseUrl}/v1/user/filter`
+
+  return {
+
+    /**
+     * Add a new saved filter
+     * @param name - The filter name
+     * @param params - The search parameters for the filter
+     * @returns The API response
+     */
+    add: async (name: string, params: SearchQueryParams) => {
+      await this.authenticate()
+      const body = this.prepareRequest(params)
+      const data = await post(`${baseFilterUrl}/add`, body, {
+        headers: this.authorizationBearerHeaders,
+        params: {
+          name,
+          wt: 'json'
+        }
+      })
+
+      return data
+    },
+
+    /**
+     * Update an existing saved filter
+     * @param name - The filter name
+     * @param params - The new search parameters for the filter
+     * @returns The API response
+     */
+    update: async (name: string, params: SearchQueryParams) => {
+      await this.authenticate()
+      const body = this.prepareRequest(params)
+      const data = await post(`${baseFilterUrl}/update`, body, {
+        headers: this.authorizationBearerHeaders,
+        params: {
+          name,
+          wt: 'json'
+        }
+      })
+
+      return data
+    },
+
+    /**
+     * Get a saved filter by name
+     * @param name - The filter name
+     * @returns The filter data
+     */
+    get: async (name: string) => {
+      await this.authenticate()
+      const data = await get(`${baseFilterUrl}/get`, {
+        headers: this.authorizationBearerHeaders,
+        params: {
+          name,
+          wt: 'json'
+        }
+      })
+
+      return data
+    },
+
+    /**
+     * Delete a saved filter
+     * @param name - The filter name
+     * @returns The API response
+     */
+    delete: async (name: string) => {
+      await this.authenticate()
+      const data = await get(`${baseFilterUrl}/delete`, {
+        headers: this.authorizationBearerHeaders,
+        params: {
+          name,
+          wt: 'json'
+        }
+      })
+
+      return data
+    },
+
+    /**
+     * List all saved filters
+     * @returns All filters
+     */
+    all: async () => {
+      await this.authenticate()
+      const data = await get(`${baseFilterUrl}/all`, {
+        headers: this.authorizationBearerHeaders,
+        params: {
+          wt: 'json'
+        }
+      })
+
+      return data
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ export const defaultSearchParams = {
   dateTo: 'now',
   size: 10,
   sortField: 'published',
-  sortOrder: 'desc'
+  sortOrder: 'desc' as const
 }
 
 export const defaultBaseUrl = 'https://afp-apicore-prod.afp.com'

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export const defaultSearchParams = {
   sortOrder: 'desc' as const
 }
 
-export const defaultBaseUrl = 'https://afp-apicore-prod.afp.com'
+export const defaultBaseUrl = 'https://afp-apicore-prod-v2-external.app.afp.com'
 
 export const maxRowsByRequest = 1000
 

--- a/src/grammar/index.ne
+++ b/src/grammar/index.ne
@@ -1,22 +1,27 @@
 @preprocessor typescript
 
 @{%
-	// Moo lexer documention is here:
-	// https://github.com/no-context/moo
+  // Moo lexer documentation is here:
+  // https://github.com/no-context/moo
 
   import moo from 'moo'
-	const lexer = moo.compile({
-	newline: { match: /\r?\n/, lineBreaks: true },
-		space: { match: /[\t\s]/, lineBreaks: true },
-	  lparen: '(',
-	  rparen: ')',
-	  dquote: '"',
-	  and: 'AND',
-	  or: 'OR',
-	  not: 'NOT',
-	  is: ':',
-	  word: /[,'\._*?@#%$a-zA-Z0-9\u0080-\uFFFF-]+/
-	});
+  const lexer = moo.compile({
+    newline: { match: /\r?\n/, lineBreaks: true },
+    space: { match: /[\t\s]/, lineBreaks: true },
+    lparen: '(',
+    rparen: ')',
+    dquote: '"',
+    backslash: '\\',
+    is: ':',
+    word: {
+      match: /[,'\._*?@#%$a-zA-Z0-9\u0080-\uFFFF-]+/,
+      type: moo.keywords({
+        and: ['AND', 'And', 'and'],
+        or: ['OR', 'Or', 'or'],
+        not: ['NOT', 'Not', 'not'],
+      })
+    }
+  });
 %}
 
 # Pass your lexer with @lexer:
@@ -24,23 +29,44 @@
 
 main -> _ logical_expression _ {% (data) => data[1] %}
 
-# Double-quoted string
-dqstring -> %dquote [^"]:* %dquote {% (data) => data[1].join('') %}
+# Double-quoted string with escape support
+dqstring -> %dquote dqchar:* %dquote {% (data) => data[1].join('') %}
+
+dqchar ->
+    %word {% (data) => data[0].text || data[0].value %}
+  | %space {% (data) => data[0].text || data[0].value %}
+  | %lparen {% () => '(' %}
+  | %rparen {% () => ')' %}
+  | %is {% () => ':' %}
+  | %and {% () => 'AND' %}
+  | %or {% () => 'OR' %}
+  | %not {% () => 'NOT' %}
+  | %newline {% (data) => data[0].text || data[0].value %}
+  | %backslash %dquote {% () => '"' %}
+  | %backslash %backslash {% () => '\\' %}
+  | %backslash %word {% (data) => {
+      const c = (data[1].text || data[1].value)[0]
+      switch (c) {
+        case 'n': return '\n' + (data[1].text || data[1].value).slice(1)
+        case 't': return '\t' + (data[1].text || data[1].value).slice(1)
+        default: return c + (data[1].text || data[1].value).slice(1)
+      }
+    } %}
 
 comparison_operator ->
-    %is {% () => ({operator: ':', type: 'ComparisonOperator'}) %}
-	
+  %is {% () => ({operator: ':', type: 'ComparisonOperator'}) %}
+
 boolean_operator ->
     %or {% () => ({operator: 'OR', type: 'BooleanOperator'}) %}
   | %and {% () => ({operator: 'AND', type: 'BooleanOperator'}) %}
- 
+
 boolean_primary ->
   tag_expression {% id %}
 
 post_boolean_primary ->
     __ %lparen _ two_op_logical_expression _ %rparen {% d => ({type: 'ParenthesizedExpression', expression: d[3]}) %}
   | __ boolean_primary {% d => d[1] %}
-  
+
 _ -> %space:?
 __ -> %space:+
 
@@ -62,7 +88,7 @@ two_op_logical_expression ->
       left: data[0],
       right: data[2]
     }) %}
-	| one_op_logical_expression {% d => d[0] %}
+  | one_op_logical_expression {% d => d[0] %}
 
 pre_two_op_implicit_logical_expression ->
     two_op_logical_expression {% d => d[0] %}
@@ -81,68 +107,69 @@ one_op_logical_expression ->
       type: 'EmptyExpression'
     }}) %}
   | %lparen _ two_op_logical_expression _ %rparen {% d => ({type: 'ParenthesizedExpression', expression: d[2]}) %}
-	|	%not post_boolean_primary {% (data) => {
-  return {
-    type: 'UnaryOperator',
-    operator: 'NOT',
-    operand: data[1]
-  };
-} %}
-| boolean_primary {% d => d[0] %}
-  
+  | %not post_boolean_primary {% (data) => {
+      return {
+        type: 'UnaryOperator',
+        operator: 'NOT',
+        operand: data[1]
+      };
+    } %}
+  | boolean_primary {% d => d[0] %}
+
 post_one_op_logical_expression ->
     __ one_op_logical_expression {% d => d[1] %}
   | %lparen _ one_op_logical_expression _ %rparen {% d => ({type: 'ParenthesizedExpression', expression: d[2]}) %}
 
 tag_expression ->
     field comparison_operator expression {% data => {
-    const field = {
-      type: 'Field',
-      name: data[0].name,
-      quoted: data[0].quoted,
-      quotes: data[0].quotes
-    };
+      const field = {
+        type: 'Field',
+        name: data[0].name,
+        quoted: data[0].quoted,
+        quotes: data[0].quotes
+      };
 
-    if (!data[0].quotes) {
-      delete field.quotes;
-    }
-
-    return {
-      field,
-      operator: data[1],
-      ...data[2]
-    }
-  } %}
-  | field comparison_operator {% data => {
-    const field = {
-      type: 'Field',
-      name: data[0].name,
-      quoted: data[0].quoted,
-      quotes: data[0].quotes
-    };
-
-    if (!data[0].quotes) {
-      delete field.quotes;
-    }
-
-    return {
-      type: 'Tag',
-      field,
-      operator: data[1],
-      expression: {
-        type: 'EmptyExpression'
+      if (!data[0].quotes) {
+        delete field.quotes;
       }
-    }
-  } %}
+
+      return {
+        type: 'Tag',
+        field,
+        operator: data[1],
+        expression: data[2].expression
+      }
+    } %}
+  | field comparison_operator {% data => {
+      const field = {
+        type: 'Field',
+        name: data[0].name,
+        quoted: data[0].quoted,
+        quotes: data[0].quotes
+      };
+
+      if (!data[0].quotes) {
+        delete field.quotes;
+      }
+
+      return {
+        type: 'Tag',
+        field,
+        operator: data[1],
+        expression: {
+          type: 'EmptyExpression'
+        }
+      }
+    } %}
   | expression {% (data) => {
-    return {field: {type: 'ImplicitField'}, ...data[0]};
-  } %}
+      return {field: {type: 'ImplicitField'}, ...data[0]};
+    } %}
 
 field ->
     %word {% ([data]) => ({type: 'LiteralExpression', name: data.text, quoted: false}) %}
   | dqstring {% ([data]) => ({type: 'LiteralExpression', name: data, quoted: true, quotes: 'double'}) %}
 
-expression -> 
+expression ->
     unquoted_value {% ([value]) => ({
       type: 'Tag',
       expression: {
@@ -150,7 +177,7 @@ expression ->
         quoted: false,
         value: value.text
       }
-  }) %}
+    }) %}
   | dqstring {% (data) => ({type: 'Tag', expression: {type: 'LiteralExpression', quoted: true, quotes: 'double', value: data.join('')}}) %}
 
 unquoted_value -> %word {% id %}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,14 @@ export type SearchQuery = {
 
 export type SearchQuerySortOrder = 'asc' | 'desc'
 
-export type AdditionalParamValue = 
-  string | 
-  number | 
-  string[] | 
-  number[] | 
+export type FacetConfig = { size: number; minDocCount: number }
+export type SortEntry = { sortField: string; sortOrder: SearchQuerySortOrder }
+
+export type AdditionalParamValue =
+  string |
+  number |
+  string[] |
+  number[] |
   {
     in?: StringOrNumber[]
     exclude?: StringOrNumber[]
@@ -30,7 +33,13 @@ export type SearchQueryParams = Partial<{
   dateFrom: string
   size: number
   langs: string[]
-  [key: string]: AdditionalParamValue
+  startAt: number
+  tz: string
+  dateGap: string
+  wantCluster: boolean
+  wantedFacets: FacetConfig[]
+  sort: SortEntry[]
+  [key: string]: AdditionalParamValue | boolean | FacetConfig[] | SortEntry[]
 }>
 
 export type AuthType = 'anonymous' | 'credentials'
@@ -62,6 +71,12 @@ export type SearchRequest = {
   uno?: string
   fields?: string[]
   lang?: string
+  startAt?: number
+  tz?: string
+  dateGap?: string
+  wantCluster?: boolean
+  wantedFacets?: FacetConfig[]
+  sort?: SortEntry[]
 }
 
 export type AuthClientCredentials = 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export type SearchQuery = {
 export type SearchQuerySortOrder = 'asc' | 'desc'
 
 export type FacetConfig = { size: number; minDocCount: number }
+export type WantedFacets = { empty?: boolean; [facetName: string]: FacetConfig | boolean | undefined }
 export type SortEntry = { sortField: string; sortOrder: SearchQuerySortOrder }
 
 export type AdditionalParamValue =
@@ -37,9 +38,9 @@ export type SearchQueryParams = Partial<{
   tz: string
   dateGap: string
   wantCluster: boolean
-  wantedFacets: FacetConfig[]
+  wantedFacets: WantedFacets
   sort: SortEntry[]
-  [key: string]: AdditionalParamValue | boolean | FacetConfig[] | SortEntry[]
+  [key: string]: AdditionalParamValue | boolean | WantedFacets | SortEntry[]
 }>
 
 export type AuthType = 'anonymous' | 'credentials'
@@ -75,7 +76,7 @@ export type SearchRequest = {
   tz?: string
   dateGap?: string
   wantCluster?: boolean
-  wantedFacets?: FacetConfig[]
+  wantedFacets?: WantedFacets
   sort?: SortEntry[]
 }
 

--- a/src/utils/QueryBuilder.ts
+++ b/src/utils/QueryBuilder.ts
@@ -1,5 +1,5 @@
 import { defaultSearchParams, maxRowsByRequest, fullTextSearchFields, langsWithTranslation } from '../config'
-import { AdditionalParamValue, FacetConfig, SearchQuery, SearchQuerySortOrder, SearchRequest, SortEntry } from "../types"
+import { AdditionalParamValue, SearchQuery, SearchQuerySortOrder, SearchRequest, SortEntry, WantedFacets } from "../types"
 import nearley from 'nearley'
 import { default as grammar } from '../grammar'
 import { normalize } from './normalizer'
@@ -24,12 +24,12 @@ export class QueryBuilder {
   public tz?: string
   public dateGap?: string
   public wantCluster?: boolean
-  public wantedFacets?: FacetConfig[]
+  public wantedFacets?: WantedFacets
   public multiSort?: SortEntry[]
   private additionalParams: SearchQuery[] = []
 
   constructor (fields?: string[]) {
-    if (this.fields) this.fields = fields
+    if (fields) this.fields = fields
     this.maxRows = defaultSearchParams.size
     this.dateFrom = defaultSearchParams.dateFrom
     this.dateTo = defaultSearchParams.dateTo
@@ -87,7 +87,7 @@ export class QueryBuilder {
     return this
   }
 
-  public setWantedFacets (wantedFacets?: FacetConfig[]) {
+  public setWantedFacets (wantedFacets?: WantedFacets) {
     if (wantedFacets) this.wantedFacets = wantedFacets
     return this
   }
@@ -97,7 +97,7 @@ export class QueryBuilder {
     return this
   }
 
-  public addAdditionalParams (additionalParams?: { [key: string]: AdditionalParamValue | boolean | FacetConfig[] | SortEntry[] | undefined }) {
+  public addAdditionalParams (additionalParams?: { [key: string]: AdditionalParamValue | boolean | WantedFacets | SortEntry[] | undefined }) {
     if (!additionalParams) return this
     for (const [key, value] of Object.entries(additionalParams)) {
       if (!value || typeof value === 'boolean') continue

--- a/src/utils/QueryBuilder.ts
+++ b/src/utils/QueryBuilder.ts
@@ -232,8 +232,21 @@ export class QueryBuilder {
     if (!queryString) return
     const typedQuery = querySchema.parse(queryString)
     const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar))
-    parser.feed(typedQuery)
-    if (parser.results.length === 0) return
+    try {
+      parser.feed(typedQuery)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      throw Object.assign(
+        new Error(`Failed to parse query "${typedQuery}": ${message}`),
+        { cause: error }
+      )
+    }
+    if (parser.results.length === 0) {
+      throw new Error(`Failed to parse query "${typedQuery}": unexpected end of input`)
+    }
+    if (parser.results.length > 1) {
+      console.warn(`Ambiguous query "${typedQuery}": ${parser.results.length} possible parses`)
+    }
     const parsedQuery = parser.results[0]
     return this.serialize(parsedQuery)
   }

--- a/src/utils/QueryBuilder.ts
+++ b/src/utils/QueryBuilder.ts
@@ -1,5 +1,5 @@
 import { defaultSearchParams, maxRowsByRequest, fullTextSearchFields, langsWithTranslation } from '../config'
-import { AdditionalParamValue, SearchQuery, SearchRequest } from "../types"
+import { AdditionalParamValue, FacetConfig, SearchQuery, SearchQuerySortOrder, SearchRequest, SortEntry } from "../types"
 import nearley from 'nearley'
 import { default as grammar } from '../grammar'
 import { normalize } from './normalizer'
@@ -17,9 +17,15 @@ export class QueryBuilder {
   public dateFrom: string
   public dateTo: string
   public sortField: string
-  public sortOrder: string
+  public sortOrder: SearchQuerySortOrder
   public langs?: string[]
   public queryString?: string
+  public startAt?: number
+  public tz?: string
+  public dateGap?: string
+  public wantCluster?: boolean
+  public wantedFacets?: FacetConfig[]
+  public multiSort?: SortEntry[]
   private additionalParams: SearchQuery[] = []
 
   constructor (fields?: string[]) {
@@ -45,7 +51,7 @@ export class QueryBuilder {
     return this
   }
 
-  public setSort (field?: string, order?: string) {
+  public setSort (field?: string, order?: SearchQuerySortOrder) {
     if (field) this.sortField = field
     if (order) this.sortOrder = order
     return this
@@ -61,11 +67,41 @@ export class QueryBuilder {
     return this
   }
 
-  public addAdditionalParams (additionalParams?: { [key: string]: AdditionalParamValue | undefined }) {
+  public setStartAt (startAt?: number) {
+    if (startAt !== undefined) this.startAt = startAt
+    return this
+  }
+
+  public setTz (tz?: string) {
+    if (tz) this.tz = tz
+    return this
+  }
+
+  public setDateGap (dateGap?: string) {
+    if (dateGap) this.dateGap = dateGap
+    return this
+  }
+
+  public setWantCluster (wantCluster?: boolean) {
+    if (wantCluster !== undefined) this.wantCluster = wantCluster
+    return this
+  }
+
+  public setWantedFacets (wantedFacets?: FacetConfig[]) {
+    if (wantedFacets) this.wantedFacets = wantedFacets
+    return this
+  }
+
+  public setMultiSort (sort?: SortEntry[]) {
+    if (sort) this.multiSort = sort
+    return this
+  }
+
+  public addAdditionalParams (additionalParams?: { [key: string]: AdditionalParamValue | boolean | FacetConfig[] | SortEntry[] | undefined }) {
     if (!additionalParams) return this
     for (const [key, value] of Object.entries(additionalParams)) {
-      if (!value) continue
-      this.addAdditionalParam(key, value)
+      if (!value || typeof value === 'boolean') continue
+      this.addAdditionalParam(key, value as AdditionalParamValue)
     }
     return this
   }
@@ -103,7 +139,7 @@ export class QueryBuilder {
   }
 
   public build () {
-    return {
+    const request: SearchRequest = {
       dateRange: {
         from: this.dateFrom,
         to: this.dateTo
@@ -114,7 +150,16 @@ export class QueryBuilder {
       lang: this.langs && this.langs.length > 0 && (!this.queryString || !this.queryString.includes('lang:')) ? this.langs.join(',') : undefined,
       fields: this.fields,
       query: this.concatenateQueryAndParams()
-    } as SearchRequest
+    }
+
+    if (this.startAt !== undefined) request.startAt = this.startAt
+    if (this.tz) request.tz = this.tz
+    if (this.dateGap) request.dateGap = this.dateGap
+    if (this.wantCluster !== undefined) request.wantCluster = this.wantCluster
+    if (this.wantedFacets) request.wantedFacets = this.wantedFacets
+    if (this.multiSort) request.sort = this.multiSort
+
+    return request
   }
 
   private serializeExpression = (expression: ExpressionToken, exclude = false, field?: FieldToken) => {

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -65,10 +65,10 @@ async function fetchJson (url: string, method: string, headers: object = {}, bod
   throw apiError(response.status, response.statusText)
 }
 
-async function fetchText (url: string, method: string, headers: object = {}, body?: string) {
+async function fetchText (url: string, method: string, headers: object = {}, body?: string, accept = 'text/*') {
   const response = await fetch(url, {
     method,
-    headers: buildHeaders(Object.assign({}, headers, { Accept: 'text/*' })),
+    headers: buildHeaders(Object.assign({}, headers, { Accept: accept })),
     body
   })
 
@@ -96,8 +96,9 @@ export async function get (
     }
     headers?: AuthorizationHeaders
   },
-  type: 'json' | 'text' = 'json') {
-  if (type === 'text') return fetchText(params ? buildUrl(url, params) : url, 'GET', headers)
+  type: 'json' | 'text' = 'json',
+  accept?: string) {
+  if (type === 'text') return fetchText(params ? buildUrl(url, params) : url, 'GET', headers, undefined, accept)
   return fetchJson(params ? buildUrl(url, params) : url, 'GET', headers)
 }
 

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -24,7 +24,7 @@ describe('Auth', () => {
   describe('constructor', () => {
     it('should use default base URL when none provided', () => {
       const auth = new Auth()
-      expect(auth.authUrl).toBe('https://afp-apicore-prod.afp.com/oauth/token')
+      expect(auth.authUrl).toBe('https://afp-apicore-prod-v2-external.app.afp.com/oauth/token')
     })
 
     it('should use custom base URL', () => {

--- a/tests/api/docs.test.ts
+++ b/tests/api/docs.test.ts
@@ -210,6 +210,46 @@ describe('Docs', () => {
       expect(calledUrl).toContain('minDocCount=1')
     })
 
+    it('should handle null topic name', async () => {
+      const listResponse = {
+        response: {
+          topics: [
+            { name: null, count: 50 },
+            { name: 'economy', count: 75 }
+          ],
+          numFound: 2
+        }
+      }
+      mockFetch(listResponse)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.list('slug')
+
+      expect(result.count).toBe(2)
+      expect(result.keywords).toHaveLength(2)
+      expect(result.keywords[0]).toEqual({ name: null, count: 50 })
+    })
+
+    it('should handle missing topic name', async () => {
+      const listResponse = {
+        response: {
+          topics: [
+            { count: 100 },
+            { name: 'politics', count: 75 }
+          ],
+          numFound: 2
+        }
+      }
+      mockFetch(listResponse)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.list('slug')
+
+      expect(result.count).toBe(2)
+      expect(result.keywords).toHaveLength(2)
+      expect(result.keywords[0]).toEqual({ count: 100 })
+    })
+
     it('should pass custom minDocCount', async () => {
       const listResponse = {
         response: { topics: [], numFound: 0 }
@@ -428,11 +468,11 @@ describe('Docs', () => {
     it('should pass wantedFacets to the API', async () => {
       mockFetch({ response: { docs: [], numFound: 0 } })
       const docs = createAuthenticatedDocs()
-      await docs.search({ wantedFacets: [{ size: 10, minDocCount: 1 }] })
+      await docs.search({ wantedFacets: { slug: { size: 10, minDocCount: 1 } } })
 
       const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
       const body = JSON.parse(calledOptions.body)
-      expect(body.wantedFacets).toEqual([{ size: 10, minDocCount: 1 }])
+      expect(body.wantedFacets).toEqual({ slug: { size: 10, minDocCount: 1 } })
     })
 
     it('should pass sort to the API', async () => {
@@ -473,41 +513,27 @@ describe('Docs', () => {
   })
 
   describe('mapping', () => {
-    it('should fetch mapping', async () => {
-      const mappingData = { fields: ['uno', 'title'] }
+    it('should fetch mapping and return response.mapping', async () => {
+      const mappingData = { response: { mapping: { fields: ['uno', 'title'] } } }
       mockFetch(mappingData)
       const docs = createAuthenticatedDocs()
-      const result = await docs.mapping()
+      const result = await docs.mapping('en')
 
-      expect(result).toEqual(mappingData)
+      expect(result).toEqual({ fields: ['uno', 'title'] })
 
       const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/mapping')
       expect(calledUrl).toContain('wt=json')
+      expect(calledUrl).toContain('lang=en')
     })
 
     it('should pass lang param', async () => {
-      mockFetch({})
+      mockFetch({ response: { mapping: {} } })
       const docs = createAuthenticatedDocs()
       await docs.mapping('fr')
 
       const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(calledUrl).toContain('lang=fr')
-    })
-  })
-
-  describe('cluster', () => {
-    it('should post to cluster endpoint', async () => {
-      const clusterData = { clusters: [] }
-      mockFetch(clusterData)
-      const docs = createAuthenticatedDocs()
-      const result = await docs.cluster({ query: 'test' })
-
-      expect(result).toEqual(clusterData)
-
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
-      expect(calledUrl).toContain('/v1/api/cluster')
-      expect(calledUrl).toContain('wt=json')
     })
   })
 
@@ -538,7 +564,7 @@ describe('Docs', () => {
   })
 
   describe('feed', () => {
-    it('should fetch feed as text', async () => {
+    it('should fetch feed as text with correct Accept header', async () => {
       const feedXml = '<rss><channel></channel></rss>'
       globalThis.fetch = vi.fn().mockResolvedValue({
         status: 200,
@@ -553,6 +579,11 @@ describe('Docs', () => {
       const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/feed')
       expect(calledUrl).toContain('filter=my-filter')
+      expect(calledUrl).toContain('wt=xml')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const headers = calledOptions.headers as Headers
+      expect(headers.get('Accept')).toBe('application/rss+xml')
     })
 
     it('should pass optional params', async () => {
@@ -562,13 +593,13 @@ describe('Docs', () => {
       })
 
       const docs = createAuthenticatedDocs()
-      await docs.feed('my-filter', { startat: 5, size: 10, role: 'admin', wt: 'xml' })
+      await docs.feed('my-filter', { startat: 5, size: 10, role: 'admin', wt: 'atom' })
 
       const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(calledUrl).toContain('startat=5')
       expect(calledUrl).toContain('size=10')
       expect(calledUrl).toContain('role=admin')
-      expect(calledUrl).toContain('wt=xml')
+      expect(calledUrl).toContain('wt=atom')
     })
   })
 

--- a/tests/api/docs.test.ts
+++ b/tests/api/docs.test.ts
@@ -346,6 +346,232 @@ describe('Docs', () => {
     })
   })
 
+  describe('wt=json query parameter', () => {
+    it('should include wt=json in search URL', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search()
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should include wt=json in get URL', async () => {
+      mockFetch({ response: { docs: [{ uno: 'AFP-123' }] } })
+      const docs = createAuthenticatedDocs()
+      await docs.get('AFP-123')
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should include wt=json in mlt URL', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.mlt('AFP-123', 'en')
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should include wt=json in list URL', async () => {
+      mockFetch({ response: { topics: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.list('slug')
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('wt=json')
+    })
+  })
+
+  describe('new search parameters', () => {
+    it('should pass startAt to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ startAt: 5 })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.startAt).toBe(5)
+    })
+
+    it('should pass tz to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ tz: 'Europe/Paris' })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.tz).toBe('Europe/Paris')
+    })
+
+    it('should pass dateGap to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ dateGap: '+1HOUR' })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.dateGap).toBe('+1HOUR')
+    })
+
+    it('should pass wantCluster to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ wantCluster: true })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.wantCluster).toBe(true)
+    })
+
+    it('should pass wantedFacets to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ wantedFacets: [{ size: 10, minDocCount: 1 }] })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.wantedFacets).toEqual([{ size: 10, minDocCount: 1 }])
+    })
+
+    it('should pass sort to the API', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.search({ sort: [{ sortField: 'published', sortOrder: 'desc' }] })
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const body = JSON.parse(calledOptions.body)
+      expect(body.sort).toEqual([{ sortField: 'published', sortOrder: 'desc' }])
+    })
+  })
+
+  describe('latest', () => {
+    it('should fetch latest documents', async () => {
+      mockFetch({ response: { docs: [{ uno: 'AFP-1' }], numFound: 1 } })
+      const docs = createAuthenticatedDocs()
+      const result = await docs.latest()
+
+      expect(result.count).toBe(1)
+      expect(result.documents).toHaveLength(1)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/api/latest')
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should pass optional params', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.latest({ lang: 'fr', tz: 'Europe/Paris', tr: 'foo' })
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('lang=fr')
+      expect(calledUrl).toContain('tz=Europe%2FParis')
+      expect(calledUrl).toContain('tr=foo')
+    })
+  })
+
+  describe('mapping', () => {
+    it('should fetch mapping', async () => {
+      const mappingData = { fields: ['uno', 'title'] }
+      mockFetch(mappingData)
+      const docs = createAuthenticatedDocs()
+      const result = await docs.mapping()
+
+      expect(result).toEqual(mappingData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/api/mapping')
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should pass lang param', async () => {
+      mockFetch({})
+      const docs = createAuthenticatedDocs()
+      await docs.mapping('fr')
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('lang=fr')
+    })
+  })
+
+  describe('cluster', () => {
+    it('should post to cluster endpoint', async () => {
+      const clusterData = { clusters: [] }
+      mockFetch(clusterData)
+      const docs = createAuthenticatedDocs()
+      const result = await docs.cluster({ query: 'test' })
+
+      expect(result).toEqual(clusterData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/api/cluster')
+      expect(calledUrl).toContain('wt=json')
+    })
+  })
+
+  describe('searchWithFilter', () => {
+    it('should search with a saved filter', async () => {
+      mockFetch({ response: { docs: [{ uno: 'AFP-1' }], numFound: 1 } })
+      const docs = createAuthenticatedDocs()
+      const result = await docs.searchWithFilter('my-filter')
+
+      expect(result.count).toBe(1)
+      expect(result.documents).toHaveLength(1)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/api/search_with_filter')
+      expect(calledUrl).toContain('filter=my-filter')
+      expect(calledUrl).toContain('wt=json')
+    })
+
+    it('should pass optional startat and size', async () => {
+      mockFetch({ response: { docs: [], numFound: 0 } })
+      const docs = createAuthenticatedDocs()
+      await docs.searchWithFilter('my-filter', { startat: 10, size: 20 })
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('startat=10')
+      expect(calledUrl).toContain('size=20')
+    })
+  })
+
+  describe('feed', () => {
+    it('should fetch feed as text', async () => {
+      const feedXml = '<rss><channel></channel></rss>'
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        text: () => Promise.resolve(feedXml)
+      })
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.feed('my-filter')
+
+      expect(result).toBe(feedXml)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/feed')
+      expect(calledUrl).toContain('filter=my-filter')
+    })
+
+    it('should pass optional params', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        status: 200,
+        text: () => Promise.resolve('')
+      })
+
+      const docs = createAuthenticatedDocs()
+      await docs.feed('my-filter', { startat: 5, size: 10, role: 'admin', wt: 'xml' })
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('startat=5')
+      expect(calledUrl).toContain('size=10')
+      expect(calledUrl).toContain('role=admin')
+      expect(calledUrl).toContain('wt=xml')
+    })
+  })
+
   describe('notificationCenter', () => {
     it('should return a notification center object', () => {
       const docs = createAuthenticatedDocs()
@@ -360,6 +586,20 @@ describe('Docs', () => {
       expect(typeof nc.subscriptionsInService).toBe('function')
       expect(typeof nc.deleteSubscription).toBe('function')
       expect(typeof nc.removeSubscriptionsFromService).toBe('function')
+    })
+  })
+
+  describe('filterCenter', () => {
+    it('should return a filter center object', () => {
+      const docs = createAuthenticatedDocs()
+      const fc = docs.filterCenter
+
+      expect(fc).toBeDefined()
+      expect(typeof fc.add).toBe('function')
+      expect(typeof fc.update).toBe('function')
+      expect(typeof fc.get).toBe('function')
+      expect(typeof fc.delete).toBe('function')
+      expect(typeof fc.all).toBe('function')
     })
   })
 })

--- a/tests/api/filter.test.ts
+++ b/tests/api/filter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Docs } from '../../src/api/docs'
+
+function mockFetch(body: unknown, status = 200) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    status,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  })
+}
+
+function createAuthenticatedDocs() {
+  const docs = new Docs()
+  docs.token = {
+    accessToken: 'test-token',
+    refreshToken: 'test-refresh',
+    tokenExpires: Date.now() + 60000,
+    authType: 'anonymous'
+  }
+  return docs
+}
+
+describe('FilterCenter', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('add', () => {
+    it('should add a filter', async () => {
+      const responseData = { response: { status: 'ok' } }
+      mockFetch(responseData)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.filterCenter.add('my-filter', { query: 'Macron' })
+
+      expect(result).toEqual(responseData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/filter/add')
+      expect(calledUrl).toContain('name=my-filter')
+      expect(calledUrl).toContain('wt=json')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      expect(calledOptions.method).toBe('POST')
+    })
+  })
+
+  describe('update', () => {
+    it('should update a filter', async () => {
+      const responseData = { response: { status: 'ok' } }
+      mockFetch(responseData)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.filterCenter.update('my-filter', { query: 'Biden' })
+
+      expect(result).toEqual(responseData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/filter/update')
+      expect(calledUrl).toContain('name=my-filter')
+      expect(calledUrl).toContain('wt=json')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      expect(calledOptions.method).toBe('POST')
+    })
+  })
+
+  describe('get', () => {
+    it('should get a filter by name', async () => {
+      const responseData = { response: { filter: { name: 'my-filter' } } }
+      mockFetch(responseData)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.filterCenter.get('my-filter')
+
+      expect(result).toEqual(responseData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/filter/get')
+      expect(calledUrl).toContain('name=my-filter')
+      expect(calledUrl).toContain('wt=json')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      expect(calledOptions.method).toBe('GET')
+    })
+  })
+
+  describe('delete', () => {
+    it('should delete a filter by name', async () => {
+      const responseData = { response: { status: 'ok' } }
+      mockFetch(responseData)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.filterCenter.delete('my-filter')
+
+      expect(result).toEqual(responseData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/filter/delete')
+      expect(calledUrl).toContain('name=my-filter')
+      expect(calledUrl).toContain('wt=json')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      expect(calledOptions.method).toBe('GET')
+    })
+  })
+
+  describe('all', () => {
+    it('should list all filters', async () => {
+      const responseData = { response: { filters: [{ name: 'filter-1' }, { name: 'filter-2' }] } }
+      mockFetch(responseData)
+
+      const docs = createAuthenticatedDocs()
+      const result = await docs.filterCenter.all()
+
+      expect(result).toEqual(responseData)
+
+      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      expect(calledUrl).toContain('/v1/user/filter/all')
+      expect(calledUrl).toContain('wt=json')
+
+      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      expect(calledOptions.method).toBe('GET')
+    })
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -28,7 +28,7 @@ describe('index exports', () => {
   })
 
   it('should export defaultBaseUrl', () => {
-    expect(defaultBaseUrl).toBe('https://afp-apicore-prod.afp.com')
+    expect(defaultBaseUrl).toBe('https://afp-apicore-prod-v2-external.app.afp.com')
   })
 
   it('should export maxRowsByRequest', () => {

--- a/tests/utils/QueryBuilder.test.ts
+++ b/tests/utils/QueryBuilder.test.ts
@@ -362,6 +362,205 @@ describe('QueryBuilder', () => {
     })
   })
 
+  describe('setStartAt', () => {
+    it('should set startAt', () => {
+      const qb = new QueryBuilder()
+      qb.setStartAt(5)
+      expect(qb.startAt).toBe(5)
+    })
+
+    it('should set startAt to 0', () => {
+      const qb = new QueryBuilder()
+      qb.setStartAt(0)
+      expect(qb.startAt).toBe(0)
+    })
+
+    it('should not set startAt when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setStartAt(undefined)
+      expect(qb.startAt).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setStartAt(0)).toBe(qb)
+    })
+  })
+
+  describe('setTz', () => {
+    it('should set timezone', () => {
+      const qb = new QueryBuilder()
+      qb.setTz('Europe/Paris')
+      expect(qb.tz).toBe('Europe/Paris')
+    })
+
+    it('should not set tz when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setTz(undefined)
+      expect(qb.tz).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setTz('UTC')).toBe(qb)
+    })
+  })
+
+  describe('setDateGap', () => {
+    it('should set dateGap', () => {
+      const qb = new QueryBuilder()
+      qb.setDateGap('+1HOUR')
+      expect(qb.dateGap).toBe('+1HOUR')
+    })
+
+    it('should not set dateGap when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setDateGap(undefined)
+      expect(qb.dateGap).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setDateGap('+1DAY')).toBe(qb)
+    })
+  })
+
+  describe('setWantCluster', () => {
+    it('should set wantCluster to true', () => {
+      const qb = new QueryBuilder()
+      qb.setWantCluster(true)
+      expect(qb.wantCluster).toBe(true)
+    })
+
+    it('should set wantCluster to false', () => {
+      const qb = new QueryBuilder()
+      qb.setWantCluster(false)
+      expect(qb.wantCluster).toBe(false)
+    })
+
+    it('should not set wantCluster when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setWantCluster(undefined)
+      expect(qb.wantCluster).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setWantCluster(true)).toBe(qb)
+    })
+  })
+
+  describe('setWantedFacets', () => {
+    it('should set wantedFacets', () => {
+      const qb = new QueryBuilder()
+      const facets = [{ size: 10, minDocCount: 1 }]
+      qb.setWantedFacets(facets)
+      expect(qb.wantedFacets).toEqual(facets)
+    })
+
+    it('should not set wantedFacets when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setWantedFacets(undefined)
+      expect(qb.wantedFacets).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setWantedFacets([])).toBe(qb)
+    })
+  })
+
+  describe('setMultiSort', () => {
+    it('should set multiSort', () => {
+      const qb = new QueryBuilder()
+      const sort = [{ sortField: 'published', sortOrder: 'desc' as const }]
+      qb.setMultiSort(sort)
+      expect(qb.multiSort).toEqual(sort)
+    })
+
+    it('should not set multiSort when undefined', () => {
+      const qb = new QueryBuilder()
+      qb.setMultiSort(undefined)
+      expect(qb.multiSort).toBeUndefined()
+    })
+
+    it('should return this for chaining', () => {
+      const qb = new QueryBuilder()
+      expect(qb.setMultiSort([])).toBe(qb)
+    })
+  })
+
+  describe('build with new fields', () => {
+    it('should include startAt when set', () => {
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setStartAt(5)
+        .build()
+
+      expect(result.startAt).toBe(5)
+    })
+
+    it('should include tz when set', () => {
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setTz('Europe/Paris')
+        .build()
+
+      expect(result.tz).toBe('Europe/Paris')
+    })
+
+    it('should include dateGap when set', () => {
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setDateGap('+1HOUR')
+        .build()
+
+      expect(result.dateGap).toBe('+1HOUR')
+    })
+
+    it('should include wantCluster when set', () => {
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setWantCluster(true)
+        .build()
+
+      expect(result.wantCluster).toBe(true)
+    })
+
+    it('should include wantedFacets when set', () => {
+      const facets = [{ size: 10, minDocCount: 1 }]
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setWantedFacets(facets)
+        .build()
+
+      expect(result.wantedFacets).toEqual(facets)
+    })
+
+    it('should include sort when multiSort is set', () => {
+      const sort = [{ sortField: 'published', sortOrder: 'desc' as const }]
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .setMultiSort(sort)
+        .build()
+
+      expect(result.sort).toEqual(sort)
+    })
+
+    it('should not include new fields when not set', () => {
+      const result = new QueryBuilder()
+        .setMaxRows(10)
+        .build()
+
+      expect(result.startAt).toBeUndefined()
+      expect(result.tz).toBeUndefined()
+      expect(result.dateGap).toBeUndefined()
+      expect(result.wantCluster).toBeUndefined()
+      expect(result.wantedFacets).toBeUndefined()
+      expect(result.sort).toBeUndefined()
+    })
+  })
+
   describe('chaining', () => {
     it('should support full fluent chain', () => {
       const result = new QueryBuilder()

--- a/tests/utils/QueryBuilder.test.ts
+++ b/tests/utils/QueryBuilder.test.ts
@@ -11,6 +11,18 @@ describe('QueryBuilder', () => {
       expect(qb.sortField).toBe('published')
       expect(qb.sortOrder).toBe('desc')
     })
+
+    it('should set fields when provided', () => {
+      const qb = new QueryBuilder(['title', 'uno'])
+      expect(qb.fields).toEqual(['title', 'uno'])
+    })
+
+    it('should include fields in build output', () => {
+      const result = new QueryBuilder(['title', 'uno'])
+        .setMaxRows(10)
+        .build()
+      expect(result.fields).toEqual(['title', 'uno'])
+    })
   })
 
   describe('setMaxRows', () => {
@@ -453,7 +465,7 @@ describe('QueryBuilder', () => {
   describe('setWantedFacets', () => {
     it('should set wantedFacets', () => {
       const qb = new QueryBuilder()
-      const facets = [{ size: 10, minDocCount: 1 }]
+      const facets = { slug: { size: 10, minDocCount: 1 } }
       qb.setWantedFacets(facets)
       expect(qb.wantedFacets).toEqual(facets)
     })
@@ -466,7 +478,7 @@ describe('QueryBuilder', () => {
 
     it('should return this for chaining', () => {
       const qb = new QueryBuilder()
-      expect(qb.setWantedFacets([])).toBe(qb)
+      expect(qb.setWantedFacets({ slug: { size: 5, minDocCount: 1 } })).toBe(qb)
     })
   })
 
@@ -528,7 +540,7 @@ describe('QueryBuilder', () => {
     })
 
     it('should include wantedFacets when set', () => {
-      const facets = [{ size: 10, minDocCount: 1 }]
+      const facets = { slug: { size: 10, minDocCount: 1 }, empty: true }
       const result = new QueryBuilder()
         .setMaxRows(10)
         .setWantedFacets(facets)

--- a/tests/utils/QueryBuilder.test.ts
+++ b/tests/utils/QueryBuilder.test.ts
@@ -349,7 +349,135 @@ describe('QueryBuilder', () => {
       const qb = new QueryBuilder()
       const result = qb.parseQueryString('()')
 
+      // Empty expression serializes to undefined
       expect(result).toBeUndefined()
+    })
+
+    it('should parse lowercase "and" keyword', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('macron and france')
+
+      expect(result).toBeDefined()
+      expect(result!.and).toBeDefined()
+    })
+
+    it('should parse lowercase "or" keyword', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('macron or merkel')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+    })
+
+    it('should parse lowercase "not" keyword', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('not country:fra')
+
+      expect(result).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('exclude')
+    })
+
+    it('should parse mixed-case keywords', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('macron And france')
+
+      expect(result).toBeDefined()
+      expect(result!.and).toBeDefined()
+    })
+
+    it('should parse "android" as a word, not AND + roid', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('android')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('android')
+    })
+
+    it('should parse "notice" as a word, not NOT + ice', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('notice')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('notice')
+    })
+
+    it('should parse "forest" as a word, not FOR + est', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('forest')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('forest')
+    })
+
+    it('should throw on unmatched parenthesis', () => {
+      const qb = new QueryBuilder()
+      expect(() => qb.parseQueryString('(Macron')).toThrow('Failed to parse query')
+    })
+
+    it('should throw on unmatched quote', () => {
+      const qb = new QueryBuilder()
+      expect(() => qb.parseQueryString('"unclosed')).toThrow('Failed to parse query')
+    })
+
+    it('should parse escaped quotes in strings', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('title:"say \\"hello\\""')
+
+      expect(result).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('say \\"hello\\"')
+    })
+
+    it('should parse escaped backslash in strings', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('title:"path\\\\file"')
+
+      expect(result).toBeDefined()
+      const flat = JSON.stringify(result)
+      expect(flat).toContain('path\\\\file')
+    })
+
+    it('should parse field with empty value (country:)', () => {
+      const qb = new QueryBuilder()
+      // Empty value after colon produces EmptyExpression which serializer cannot handle
+      expect(() => qb.parseQueryString('country:')).toThrow()
+    })
+
+    it('should parse double parentheses', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('((Macron))')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+    })
+
+    it("should parse French apostrophe (l'AFP)", () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString("l'AFP")
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+      const flat = JSON.stringify(result)
+      // normalizer lowercases the text
+      expect(flat).toContain("l'afp")
+    })
+
+    it('should parse hyphenated words (Jean-Luc)', () => {
+      const qb = new QueryBuilder()
+      const result = qb.parseQueryString('Jean-Luc')
+
+      expect(result).toBeDefined()
+      expect(result!.or).toBeDefined()
+      const flat = JSON.stringify(result)
+      // normalizer lowercases the text
+      expect(flat).toContain('jean-luc')
     })
 
     it('should handle full-text search fields with translation', () => {


### PR DESCRIPTION
## Summary
- **#83** Fix fields parameter ignored in QueryBuilder constructor (`if (this.fields)` → `if (fields)`)
- **#84** Fix wantedFacets type: changed from `FacetConfig[]` to `WantedFacets` dictionary (`{ facetName: { size, minDocCount }, empty?: boolean }`)
- **#85** Remove cluster method from dev (not yet implemented server-side)
- **#86** Fix Zod error on list route: topic `name` can be `null` or absent (`z.string().nullable().optional()`)
- **#87** Make `mapping(lang)` parameter required, add Zod validation, return `response.mapping`
- **#88** Fix feed 406 error: send `Accept: application/rss+xml` header, default `wt=xml`

Also includes: updated base URL, new FilterCenter, updated README, updated tests.

Closes #83, closes #84, closes #85, closes #86, closes #87, closes #88

## Test plan
- [x] All 174 tests passing
- [x] Lint clean
- [ ] Manual test against staging API

🤖 Generated with [Claude Code](https://claude.com/claude-code)