### PR TITLE
feat: expose parseShotList (shared video shot list parser)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afpnews-api",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Node helper functions to authenticate and fetch AFP Core API",
   "main": "dist/cjs/index.js",
   "type": "commonjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 export { Docs as ApiCore } from './api/docs'
 export type * from './types'
 export * from './config'
+export { parseShotList, timeToSeconds } from './utils/shotlist'
+export type { Shot, Citation } from './utils/shotlist'

--- a/src/utils/shotlist.ts
+++ b/src/utils/shotlist.ts
@@ -1,0 +1,93 @@
+/**
+ * Parse la shot list d'une vidéo AFP à partir d'un texte brut (gère SONORE et SOUNDBITE).
+ * Tolère les erreurs de format et extrait les durées de chaque plan.
+ */
+
+export interface Citation {
+  text: string
+}
+
+export interface Shot {
+  numero: number
+  start: string
+  end: string
+  startSec: number
+  endSec: number
+  description: string
+  citations: Citation[]
+}
+
+export function timeToSeconds (time: string): number {
+  const [minutes = 0, seconds = 0] = time.split(':').map(Number)
+  return minutes * 60 + seconds
+}
+
+export function parseShotList (input: string): Shot[] {
+  const lines = input.split('\n').map(line => line.trim())
+  const shots: Shot[] = []
+
+  const shotRegex = /^(\d+)\.\s+(\d{2}:\d{2})-(\d{2}:\d{2})\s+(.*)$/
+  const soundbiteRegex =
+    /^(\d+)\.\s+(\d{2}:\d{2})-(\d{2}:\d{2})\s+(?:SONORE|SOUNDBITE) \d+ - (.*)$/i
+
+  let currentShot: Shot | null = null
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+
+    if (!line) continue
+
+    const matchSoundbite = line.match(soundbiteRegex)
+    if (matchSoundbite) {
+      const [, numero = '', start = '', end = '', description = ''] =
+        matchSoundbite
+      currentShot = {
+        numero: parseInt(numero || '0', 10),
+        start: start || '00:00',
+        end: end || '00:00',
+        startSec: timeToSeconds(start || '00:00'),
+        endSec: timeToSeconds(end || '00:00'),
+        description: description || '',
+        citations: []
+      }
+      shots.push(currentShot)
+      continue
+    }
+
+    const matchShot = line.match(shotRegex)
+    if (matchShot && !line.includes('SOUNDBITE') && !line.includes('SONORE')) {
+      const [, numero = '', start = '', end = '', description = ''] = matchShot
+      currentShot = {
+        numero: parseInt(numero || '0', 10),
+        start: start || '00:00',
+        end: end || '00:00',
+        startSec: timeToSeconds(start || '00:00'),
+        endSec: timeToSeconds(end || '00:00'),
+        description: description || '',
+        citations: []
+      }
+      shots.push(currentShot)
+      continue
+    }
+
+    // Traiter les citations s'il y a un plan courant
+    if (currentShot && line.startsWith('"') && line.endsWith('"')) {
+      const citationText = line.slice(1, -1)
+      currentShot.citations.push({ text: citationText })
+      continue
+    }
+
+    // Gestion des erreurs de format
+    if (
+      currentShot &&
+      currentShot.description.startsWith('SOUNDBITE') &&
+      line &&
+      !line.startsWith('"')
+    ) {
+      // Peut être un début de citation oubliant les guillemets
+      currentShot.citations.push({ text: line })
+    }
+  }
+
+  return shots
+}

--- a/tests/utils/shotlist.test.ts
+++ b/tests/utils/shotlist.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { parseShotList, timeToSeconds } from '../../src/utils/shotlist'
+
+describe('timeToSeconds', () => {
+  it('converts mm:ss to seconds', () => {
+    expect(timeToSeconds('00:00')).toBe(0)
+    expect(timeToSeconds('00:12')).toBe(12)
+    expect(timeToSeconds('01:30')).toBe(90)
+    expect(timeToSeconds('10:05')).toBe(605)
+  })
+})
+
+describe('parseShotList', () => {
+  it('parses a simple shot line', () => {
+    const shots = parseShotList('1. 00:00-00:12 Vue aérienne de la ville')
+    expect(shots).toHaveLength(1)
+    expect(shots[0]).toMatchObject({
+      numero: 1,
+      start: '00:00',
+      end: '00:12',
+      startSec: 0,
+      endSec: 12,
+      description: 'Vue aérienne de la ville',
+      citations: []
+    })
+  })
+
+  it('parses several shots separated by newlines', () => {
+    const input = [
+      '1. 00:00-00:12 Vue aérienne de la ville',
+      '2. 00:12-00:30 Plan rapproché sur le monument'
+    ].join('\n')
+    const shots = parseShotList(input)
+    expect(shots).toHaveLength(2)
+    expect(shots[1]).toMatchObject({ numero: 2, startSec: 12, endSec: 30 })
+  })
+
+  it('parses a SOUNDBITE shot and attaches its citation', () => {
+    const input = [
+      '1. 00:12-00:30 SOUNDBITE 1 - Jean Dupont, témoin',
+      '"Tout a commencé très vite"'
+    ].join('\n')
+    const shots = parseShotList(input)
+    expect(shots).toHaveLength(1)
+    expect(shots[0]).toMatchObject({
+      numero: 1,
+      description: 'Jean Dupont, témoin',
+      citations: [{ text: 'Tout a commencé très vite' }]
+    })
+  })
+
+  it('parses a SONORE shot (case-insensitive)', () => {
+    const shots = parseShotList('2. 00:30-00:45 sonore 2 - Marie Martin')
+    expect(shots).toHaveLength(1)
+    expect(shots[0]).toMatchObject({
+      numero: 2,
+      description: 'Marie Martin'
+    })
+  })
+
+  it('ignores lines that do not match the shot format', () => {
+    const input = [
+      'Titre de la shot list',
+      '1. 00:00-00:12 Premier plan',
+      'note libre sans timecode'
+    ].join('\n')
+    const shots = parseShotList(input)
+    expect(shots).toHaveLength(1)
+    expect(shots[0]?.description).toBe('Premier plan')
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(parseShotList('')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Contexte

Le parser de shot list vidéo (ex-« dopesheet ») vivait dans `afpnews-deck`, alors qu'`afpnews-mcp-server` en a aussi besoin pour rendre correctement les vidéos. Cette PR en fait **une seule implémentation partagée** dans le SDK.

## Changements

- `src/utils/shotlist.ts` : `parseShotList(text): Shot[]`, `timeToSeconds`, types `Shot`/`Citation` (copie fidèle du parser éprouvé du deck).
- Exportés depuis l'index (runtime esm+cjs + déclarations `.d.ts`).
- Tests vitest dédiés.

Purement **additif** : aucun export existant modifié. `2.4.2` → `2.5.0`.

## Suite

Consommé par `afpnews-mcp-server` (rendu shot list) et `afpnews-deck` (viewer + IA), pour une cohérence deep-link `?t=` de bout en bout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)