### PR TITLE
ci: add GitHub Actions workflow (lint, build, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Lint, build and test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 26
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## Summary
This repo has no CI at all today — the only gate before merging anything is whatever gets run locally. Adds `.github/workflows/ci.yml`, which runs on every push to `master` and every PR targeting `master`:
- `pnpm install --frozen-lockfile`
- `npm run lint` (eslint)
- `npm run build` (full multi-target build: types/esm/cjs/bundles)
- `npm test` (vitest, 198 tests)

Mirrors the existing npm scripts already used locally and in the `prepare` lifecycle script. Uses `pnpm/action-setup@v4` (pinned to pnpm 11, matching the local toolchain) and `actions/setup-node@v5` (Node 26).

Verified locally: `pnpm install --frozen-lockfile && npm run lint && npm run build && npm test` all pass on current `master` (198/198 tests).

**Not merging this PR** — leaving it open for manual review as requested.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>