### PR TITLE
chore(lint): enable type-aware oxlint rules (matches recommendedTypeChecked)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,6 +9,9 @@
   "env": {
     "builtin": true
   },
+  "options": {
+    "typeAware": true
+  },
   "ignorePatterns": [
     "node_modules",
     "dist",
@@ -95,7 +98,30 @@
     "typescript/no-wrapper-object-types": "error",
     "typescript/prefer-as-const": "error",
     "typescript/prefer-namespace-keyword": "error",
-    "typescript/triple-slash-reference": "error"
+    "typescript/triple-slash-reference": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-array-delete": "error",
+    "typescript/no-base-to-string": "error",
+    "typescript/no-duplicate-type-constituents": "error",
+    "typescript/no-floating-promises": "error",
+    "typescript/no-for-in-array": "error",
+    "typescript/no-implied-eval": "error",
+    "typescript/no-misused-promises": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/no-unnecessary-type-assertion": "error",
+    "typescript/no-unsafe-argument": "error",
+    "typescript/no-unsafe-assignment": "error",
+    "typescript/no-unsafe-call": "error",
+    "typescript/no-unsafe-enum-comparison": "error",
+    "typescript/no-unsafe-member-access": "error",
+    "typescript/no-unsafe-return": "error",
+    "typescript/no-unsafe-unary-minus": "error",
+    "typescript/only-throw-error": "error",
+    "typescript/prefer-promise-reject-errors": "error",
+    "typescript/require-await": "error",
+    "typescript/restrict-plus-operands": "error",
+    "typescript/restrict-template-expressions": "error",
+    "typescript/unbound-method": "error"
   },
   "overrides": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,10 @@ dist/
 - **TypeScript strict mode**: All strict checks enabled (`noImplicitAny`, `strictNullChecks`, `noUnusedLocals`, `noUnusedParameters`, etc.)
 
 ### Linting
-- [oxlint](https://oxc.rs/docs/guide/usage/linter.html) (`.oxlintrc.json`), not type-aware (matches the previous ESLint config's non-type-checked `recommended` preset)
+- [oxlint](https://oxc.rs/docs/guide/usage/linter.html) (`.oxlintrc.json`), type-aware via `oxlint-tsgolint` (`options.typeAware: true`) — the enabled `typescript/*` rule set matches `typescript-eslint`'s `recommendedTypeChecked` preset (the non-type-checked `recommended` rules, plus its `recommended-type-checked-only` additions)
 - Ignored paths: `node_modules`, `dist`, `src/grammar/index.ts` (generated), `examples`, `tools`
 - Run with: `npm run lint`
+- Test-only `fetch` mocks are typed via `tests/helpers/mockFetch.ts` (`Mock<typeof fetch>`) rather than each test file rolling its own loosely-typed mock
 
 ### TypeScript
 - Target: ES6, Module: ESNext, Lib: ES2015

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "verify:package": "npm run build:parser && tsdown --publint --attw",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint .",
+    "lint": "npm run build:parser && oxlint .",
     "prepare": "npm run lint && npm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "devDependencies": {
     "@arethetypeswrong/core": "^0.18.5",
     "oxlint": "^1.74.0",
+    "oxlint-tsgolint": "^0.24.0",
     "publint": "^0.3.21",
     "rimraf": "^6.1.3",
     "tsdown": "^0.22.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,10 @@ importers:
         version: 0.18.5
       oxlint:
         specifier: ^1.74.0
-        version: 1.74.0
+        version: 1.74.0(oxlint-tsgolint@0.24.0)
+      oxlint-tsgolint:
+        specifier: ^0.24.0
+        version: 0.24.0
       publint:
         specifier: ^0.3.21
         version: 0.3.21
@@ -281,6 +284,36 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-C2uMmwK5Bc4ri4ysZ6sA8Rcu+A5zBQTp6ml2u0CLLbRZp4kMFPV3yWk8B5DK9Aw7y9bbjogIm75tUwGLFzlsYQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-Wgvt/1lRbDxmoNqWQKKcL+UIiqLmdJ+EWLpQa1qzoNVAfNB0PJpa82/8dH1twT/3rSs4zrP5TXPWl4juB71WuQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-PB1rxII7KV83+ASY4sSkXtqvpij6ME66+QCRL49uksi/ofs2Rf/UVboYr095n0Rkbl2wgvlsHGl6DHC361jQUQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    resolution: {integrity: sha512-xcz3CxKmjTQLREtE/UShh+ruWmm9nAb7UM9zKcD65BStiuYgOakAKkPHl4YS5DztpVcDrE0+HqbOolTlRKYWmw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-A2i6ZGBec3i20S7RaxkgHc6r3HYtD5Mn7j/mb22NkTz14u0JuudvTu6JggAnbGMcv8+dBKQI//EasxSPJLD8pw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    resolution: {integrity: sha512-0ZbGd9qRB6zs82moekaKdEvncRANq49EAwfNX62JpTS46feXUhKAuoyVDvZMj6Rywejylrmmu79Wo6faYCo4Ew==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.74.0':
     resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
@@ -1103,6 +1136,10 @@ packages:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
 
+  oxlint-tsgolint@0.24.0:
+    resolution: {integrity: sha512-giCk5sEvG02d5tzPmFMX3hem8ndzEEu1xvGYS5OwNfO2WGl6ZVxt5LjE0yiMDoz94INI7XkXwgFAQiydPvVHDw==}
+    hasBin: true
+
   oxlint@1.74.0:
     resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1554,6 +1591,24 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.139.0': {}
+
+  '@oxlint-tsgolint/darwin-arm64@0.24.0':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@0.24.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@0.24.0':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@0.24.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@0.24.0':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@0.24.0':
+    optional: true
 
   '@oxlint/binding-android-arm-eabi@1.74.0':
     optional: true
@@ -2070,7 +2125,16 @@ snapshots:
 
   obug@2.1.3: {}
 
-  oxlint@1.74.0:
+  oxlint-tsgolint@0.24.0:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 0.24.0
+      '@oxlint-tsgolint/darwin-x64': 0.24.0
+      '@oxlint-tsgolint/linux-arm64': 0.24.0
+      '@oxlint-tsgolint/linux-x64': 0.24.0
+      '@oxlint-tsgolint/win32-arm64': 0.24.0
+      '@oxlint-tsgolint/win32-x64': 0.24.0
+
+  oxlint@1.74.0(oxlint-tsgolint@0.24.0):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.74.0
       '@oxlint/binding-android-arm64': 1.74.0
@@ -2091,6 +2155,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.74.0
       '@oxlint/binding-win32-ia32-msvc': 1.74.0
       '@oxlint/binding-win32-x64-msvc': 1.74.0
+      oxlint-tsgolint: 0.24.0
 
   package-json-from-dist@1.0.1: {}
 

--- a/src/utils/QueryBuilder.ts
+++ b/src/utils/QueryBuilder.ts
@@ -247,7 +247,9 @@ export class QueryBuilder {
     if (parser.results.length > 1) {
       console.warn(`Ambiguous query "${typedQuery}": ${parser.results.length} possible parses`)
     }
-    const parsedQuery = parser.results[0]
+    // nearley's parser.results is typed `any[]`; the grammar guarantees each
+    // result matches the Ast shape declared in grammar/grammar.d.ts.
+    const parsedQuery = parser.results[0] as Ast
     return this.serialize(parsedQuery)
   }
 }

--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -9,19 +9,19 @@ const errorSchema = z.object({
   })
 })
 
-function buildUrl (url: string, params: object) {
+function buildUrl (url: string, params: Record<string, string | number>) {
   const builtUrl = new URL(url)
-  Object.entries(params).forEach(([key, value]) => builtUrl.searchParams.append(key, value))
+  Object.entries(params).forEach(([key, value]) => builtUrl.searchParams.append(key, String(value)))
   return builtUrl.toString()
 }
 
-function buildHeaders (headers: object) {
+function buildHeaders (headers: Record<string, string>) {
   const builtHeaders = new Headers()
   Object.entries(headers).forEach(([key, value]) => builtHeaders.append(key, value))
   return builtHeaders
 }
 
-function buildForm (form: object) {
+function buildForm (form: AuthForm) {
   const builtForm = new FormData()
   Object.entries(form).forEach(([key, value]) => builtForm.append(key, value))
   return builtForm
@@ -52,7 +52,7 @@ async function fetchJson (url: string, method: string, headers: object = {}, bod
     body
   })
 
-  const data = await response.json();  
+  const data: unknown = await response.json();
 
   // AFP peut retourner HTTP 200 avec un payload d'erreur — vérifier dans les deux cas
   const errorData = errorSchema.safeParse(data);                                                                              

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -1,19 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { Auth } from '../../src/api/auth'
+import { mockFetch } from '../helpers/mockFetch'
 
 const TOKEN_RESPONSE = {
   access_token: 'test-access-token',
   refresh_token: 'test-refresh-token',
   expires_in: 3600
-}
-
-function mockFetch(body: unknown, status = 200) {
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    status,
-    statusText: 'OK',
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body))
-  })
 }
 
 describe('Auth', () => {
@@ -111,11 +103,11 @@ describe('Auth', () => {
       const auth = new Auth()
 
       const token1 = await auth.authenticate()
-      const fetchCallCount = (fetch as ReturnType<typeof vi.fn>).mock.calls.length
+      const fetchCallCount = (fetch as Mock<typeof fetch>).mock.calls.length
 
       const token2 = await auth.authenticate()
       expect(token2).toBe(token1)
-      expect((fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(fetchCallCount)
+      expect((fetch as Mock<typeof fetch>).mock.calls.length).toBe(fetchCallCount)
     })
 
     it('should refresh anonymous token when expired', async () => {
@@ -158,7 +150,7 @@ describe('Auth', () => {
       expect(token.accessToken).toBe('test-access-token')
       expect(token.authType).toBe('credentials')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('POST')
     })
 
@@ -269,7 +261,7 @@ describe('Auth', () => {
       expect(result.user.additionalProperties.infosLdap.mail).toBe('test@example.com')
       expect(result.user.additionalProperties.infosLdap.uid).toBe('TESTUSER')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/me')
     })
 

--- a/tests/api/docs.test.ts
+++ b/tests/api/docs.test.ts
@@ -1,28 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { Docs } from '../../src/api/docs'
+import type { SearchRequest } from '../../src/types'
+import { mockFetch, mockFetchSequence } from '../helpers/mockFetch'
 
 const TOKEN_RESPONSE = {
   access_token: 'test-access-token',
   refresh_token: 'test-refresh-token',
   expires_in: 3600
-}
-
-function mockFetchSequence(responses: Array<{ body: unknown; status?: number }>) {
-  let callIndex = 0
-  globalThis.fetch = vi.fn().mockImplementation(() => {
-    const resp = responses[callIndex] || responses[responses.length - 1]
-    callIndex++
-    return Promise.resolve({
-      status: resp.status || 200,
-      statusText: 'OK',
-      json: () => Promise.resolve(resp.body),
-      text: () => Promise.resolve(JSON.stringify(resp.body))
-    })
-  })
-}
-
-function mockFetch(body: unknown, status = 200) {
-  mockFetchSequence([{ body, status }])
 }
 
 function createAuthenticatedDocs() {
@@ -102,11 +86,11 @@ describe('Docs', () => {
         sortOrder: 'desc'
       })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/search')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.maxRows).toBe(20)
       expect(body.dateRange.from).toBe('2023-01-01')
       expect(body.dateRange.to).toBe('2023-12-31')
@@ -121,8 +105,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search()
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.maxRows).toBe(10)
       expect(body.sortField).toBe('published')
       expect(body.sortOrder).toBe('desc')
@@ -143,7 +127,7 @@ describe('Docs', () => {
 
       expect(result).toEqual({ uno: 'AFP-123', title: 'Test Document' })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/get/AFP-123')
     })
   })
@@ -164,7 +148,7 @@ describe('Docs', () => {
       expect(result.count).toBe(2)
       expect(result.documents).toHaveLength(2)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/mlt')
       expect(calledUrl).toContain('uno=AFP-123')
       expect(calledUrl).toContain('lang=en')
@@ -180,7 +164,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.mlt('AFP-123', 'fr')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('size=10')
     })
   })
@@ -205,7 +189,7 @@ describe('Docs', () => {
       expect(result.keywords).toHaveLength(2)
       expect(result.keywords[0]).toEqual({ name: 'politics', count: 150 })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/list/slug')
       expect(calledUrl).toContain('minDocCount=1')
     })
@@ -259,7 +243,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.list('keyword', {}, 5)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('minDocCount=5')
     })
   })
@@ -271,26 +255,26 @@ describe('Docs', () => {
       // Mock search to simulate pagination: 2 pages of 3 docs each
       const searchSpy = vi.spyOn(docs, 'search')
       let callNum = 0
-      searchSpy.mockImplementation(async () => {
+      searchSpy.mockImplementation(() => {
         callNum++
         if (callNum === 1) {
-          return {
+          return Promise.resolve({
             count: 6,
             documents: [
               { uno: 'doc1', published: '2023-06-15T12:00:00Z' },
               { uno: 'doc2', published: '2023-06-14T12:00:00Z' },
               { uno: 'doc3', published: '2023-06-13T12:00:00Z' }
             ]
-          }
+          })
         }
-        return {
+        return Promise.resolve({
           count: 6,
           documents: [
             { uno: 'doc4', published: '2023-06-12T12:00:00Z' },
             { uno: 'doc5', published: '2023-06-11T12:00:00Z' },
             { uno: 'doc6', published: '2023-06-10T12:00:00Z' }
           ]
-        }
+        })
       })
 
       const collected: unknown[] = []
@@ -310,7 +294,7 @@ describe('Docs', () => {
 
       const searchSpy = vi.spyOn(docs, 'search')
       let callNum = 0
-      searchSpy.mockImplementation(async () => {
+      searchSpy.mockImplementation(() => {
         callNum++
         if (callNum === 1) {
           // Return exactly 1000 docs (matching maxRequestSize) so pagination continues
@@ -318,14 +302,14 @@ describe('Docs', () => {
             uno: `doc-${i}`,
             published: `2023-06-${String(15).padStart(2, '0')}T${String(i).padStart(2, '0')}:00:00Z`
           }))
-          return { count: 1500, documents: pageDocs }
+          return Promise.resolve({ count: 1500, documents: pageDocs })
         }
         // Second page: fewer than requested → stops
         const pageDocs = Array.from({ length: 100 }, (_, i) => ({
           uno: `doc-${1000 + i}`,
           published: `2023-06-14T${String(i).padStart(2, '0')}:00:00Z`
         }))
-        return { count: 1500, documents: pageDocs }
+        return Promise.resolve({ count: 1500, documents: pageDocs })
       })
 
       const collected: unknown[] = []
@@ -392,7 +376,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search()
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('wt=json')
     })
 
@@ -401,7 +385,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.get('AFP-123')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('wt=json')
     })
 
@@ -410,7 +394,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.mlt('AFP-123', 'en')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('wt=json')
     })
 
@@ -419,7 +403,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.list('slug')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('wt=json')
     })
   })
@@ -430,8 +414,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ startAt: 5 })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.startAt).toBe(5)
     })
 
@@ -440,8 +424,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ tz: 'Europe/Paris' })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.tz).toBe('Europe/Paris')
     })
 
@@ -450,8 +434,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ dateGap: '+1HOUR' })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.dateGap).toBe('+1HOUR')
     })
 
@@ -460,8 +444,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ wantCluster: true })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.wantCluster).toBe(true)
     })
 
@@ -470,8 +454,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ wantedFacets: { slug: { size: 10, minDocCount: 1 } } })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.wantedFacets).toEqual({ slug: { size: 10, minDocCount: 1 } })
     })
 
@@ -480,8 +464,8 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.search({ sort: [{ sortField: 'published', sortOrder: 'desc' }] })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
-      const body = JSON.parse(calledOptions.body)
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
+      const body = JSON.parse(calledOptions.body as string) as SearchRequest
       expect(body.sort).toEqual([{ sortField: 'published', sortOrder: 'desc' }])
     })
   })
@@ -495,7 +479,7 @@ describe('Docs', () => {
       expect(result.count).toBe(1)
       expect(result.documents).toHaveLength(1)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/latest')
       expect(calledUrl).toContain('wt=json')
     })
@@ -505,7 +489,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.latest({ lang: 'fr', tz: 'Europe/Paris', tr: 'foo' })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('lang=fr')
       expect(calledUrl).toContain('tz=Europe%2FParis')
       expect(calledUrl).toContain('tr=foo')
@@ -521,7 +505,7 @@ describe('Docs', () => {
 
       expect(result).toEqual({ fields: ['uno', 'title'] })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/mapping')
       expect(calledUrl).toContain('wt=json')
       expect(calledUrl).toContain('lang=en')
@@ -532,7 +516,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.mapping('fr')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('lang=fr')
     })
   })
@@ -546,7 +530,7 @@ describe('Docs', () => {
       expect(result.count).toBe(1)
       expect(result.documents).toHaveLength(1)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/api/search_with_filter')
       expect(calledUrl).toContain('filter=my-filter')
       expect(calledUrl).toContain('wt=json')
@@ -557,7 +541,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.searchWithFilter('my-filter', { startat: 10, size: 20 })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('startat=10')
       expect(calledUrl).toContain('size=20')
     })
@@ -576,12 +560,12 @@ describe('Docs', () => {
 
       expect(result).toBe(feedXml)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/feed')
       expect(calledUrl).toContain('filter=my-filter')
       expect(calledUrl).toContain('wt=xml')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       const headers = calledOptions.headers as Headers
       expect(headers.get('Accept')).toBe('application/rss+xml')
     })
@@ -595,7 +579,7 @@ describe('Docs', () => {
       const docs = createAuthenticatedDocs()
       await docs.feed('my-filter', { startat: 5, size: 10, role: 'admin', wt: 'atom' })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('startat=5')
       expect(calledUrl).toContain('size=10')
       expect(calledUrl).toContain('role=admin')

--- a/tests/api/filter.test.ts
+++ b/tests/api/filter.test.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { Docs } from '../../src/api/docs'
-
-function mockFetch(body: unknown, status = 200) {
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    status,
-    statusText: 'OK',
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body))
-  })
-}
+import { mockFetch } from '../helpers/mockFetch'
 
 function createAuthenticatedDocs() {
   const docs = new Docs()
@@ -36,12 +28,12 @@ describe('FilterCenter', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/filter/add')
       expect(calledUrl).toContain('name=my-filter')
       expect(calledUrl).toContain('wt=json')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('POST')
     })
   })
@@ -56,12 +48,12 @@ describe('FilterCenter', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/filter/update')
       expect(calledUrl).toContain('name=my-filter')
       expect(calledUrl).toContain('wt=json')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('POST')
     })
   })
@@ -76,12 +68,12 @@ describe('FilterCenter', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/filter/get')
       expect(calledUrl).toContain('name=my-filter')
       expect(calledUrl).toContain('wt=json')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('GET')
     })
   })
@@ -96,12 +88,12 @@ describe('FilterCenter', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/filter/delete')
       expect(calledUrl).toContain('name=my-filter')
       expect(calledUrl).toContain('wt=json')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('GET')
     })
   })
@@ -116,11 +108,11 @@ describe('FilterCenter', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/v1/user/filter/all')
       expect(calledUrl).toContain('wt=json')
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('GET')
     })
   })

--- a/tests/api/notification.test.ts
+++ b/tests/api/notification.test.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { Docs } from '../../src/api/docs'
-
-function mockFetch(body: unknown, status = 200) {
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    status,
-    statusText: 'OK',
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body))
-  })
-}
+import { mockFetch } from '../helpers/mockFetch'
 
 function createAuthenticatedDocs() {
   const docs = new Docs()
@@ -39,7 +31,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       })
 
       expect(uno).toBe('service-123')
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/notification/api/service/register')
     })
 
@@ -105,7 +97,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       const uno = await nc.deleteService('myService')
 
       expect(uno).toBe('deleted-123')
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/notification/api/service/delete')
       expect(calledUrl).toContain('service=myService')
     })
@@ -122,7 +114,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       })
 
       expect(uno).toBe('sub-123')
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/notification/api/subscription/add')
       expect(calledUrl).toContain('name=mySub')
       expect(calledUrl).toContain('service=myService')
@@ -166,7 +158,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       const subs = await nc.subscriptionsInService('myService')
 
       expect(subs).toHaveLength(2)
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/notification/api/service/subscriptions')
       expect(calledUrl).toContain('service=myService')
     })
@@ -198,7 +190,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       const nc = docs.notificationCenter
       await nc.deleteSubscription('myService', 'mySub')
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('/notification/api/subscription/delete')
       expect(calledUrl).toContain('service=myService')
       expect(calledUrl).toContain('name=mySub')
@@ -223,7 +215,7 @@ describe('NotificationCenter (via Docs.notificationCenter)', () => {
       expect(result).toHaveLength(2)
       expect(result[0]).toEqual({ name: 'sub1', status: 'deleted' })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('DELETE')
       expect(calledOptions.body).toBe(JSON.stringify(['sub1', 'sub2']))
     })

--- a/tests/helpers/mockFetch.ts
+++ b/tests/helpers/mockFetch.ts
@@ -1,0 +1,40 @@
+import { vi, type Mock } from 'vitest'
+
+interface FetchResponseInit {
+  body: unknown
+  status?: number
+  statusText?: string
+}
+
+function buildResponse ({ body, status = 200, statusText = 'OK' }: FetchResponseInit): Response {
+  // Only the Response members this codebase actually reads are implemented.
+  return {
+    status,
+    statusText,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body))
+  } as Response
+}
+
+/**
+ * Creates a typed `fetch` mock resolving to a single response.
+ * Assign it to `globalThis.fetch` or inspect it directly via `.mock.calls`.
+ */
+export function mockFetchResponse (body: unknown, status = 200, statusText = 'OK'): Mock<typeof fetch> {
+  return vi.fn<typeof fetch>(() => Promise.resolve(buildResponse({ body, status, statusText })))
+}
+
+/** Assigns `globalThis.fetch` to a mock resolving to a single response. */
+export function mockFetch (body: unknown, status = 200, statusText = 'OK'): void {
+  globalThis.fetch = mockFetchResponse(body, status, statusText)
+}
+
+/** Assigns `globalThis.fetch` to a mock resolving to successive responses, one per call. */
+export function mockFetchSequence (responses: FetchResponseInit[]): void {
+  let callIndex = 0
+  globalThis.fetch = vi.fn<typeof fetch>(() => {
+    const resp = responses[callIndex] || responses[responses.length - 1]
+    callIndex++
+    return Promise.resolve(buildResponse(resp))
+  })
+}

--- a/tests/utils/QueryBuilder.test.ts
+++ b/tests/utils/QueryBuilder.test.ts
@@ -289,6 +289,8 @@ describe('QueryBuilder', () => {
       expect(result!.or).toBeDefined()
       expect(result!.or).toEqual(
         expect.arrayContaining([
+          // vitest's asymmetric matchers (arrayContaining/objectContaining) are typed to return `any`
+          // eslint-disable-next-line typescript/no-unsafe-assignment
           expect.objectContaining({ name: 'country', in: expect.arrayContaining(['fra']) })
         ])
       )

--- a/tests/utils/request.test.ts
+++ b/tests/utils/request.test.ts
@@ -1,14 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import { get, post, postForm, del } from '../../src/utils/request'
-
-function mockFetchResponse(body: unknown, status = 200, statusText = 'OK') {
-  return vi.fn().mockResolvedValue({
-    status,
-    statusText,
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body))
-  })
-}
+import { mockFetchResponse } from '../helpers/mockFetch'
 
 describe('request utilities', () => {
   beforeEach(() => {
@@ -36,7 +28,7 @@ describe('request utilities', () => {
         params: { grant_type: 'anonymous', foo: 'bar' }
       })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('grant_type=anonymous')
       expect(calledUrl).toContain('foo=bar')
     })
@@ -48,7 +40,7 @@ describe('request utilities', () => {
         headers: { Authorization: 'Bearer token123' }
       })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       const headers = calledOptions.headers as Headers
       expect(headers.get('Authorization')).toBe('Bearer token123')
       expect(headers.get('Accept')).toBe('application/json')
@@ -62,23 +54,15 @@ describe('request utilities', () => {
     })
 
     it('should throw ApiError on HTTP error with error body', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        status: 401,
-        statusText: 'Unauthorized',
-        json: () => Promise.resolve({
-          error: { code: 401, message: 'Invalid token; please re-authenticate' }
-        })
-      })
+      globalThis.fetch = mockFetchResponse({
+        error: { code: 401, message: 'Invalid token; please re-authenticate' }
+      }, 401, 'Unauthorized')
 
       await expect(get('https://api.example.com/test', {})).rejects.toThrow('Invalid token')
     })
 
     it('should throw ApiError with status text when error body is not parseable', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValue({
-        status: 500,
-        statusText: 'Internal Server Error',
-        json: () => Promise.resolve({ unexpected: 'format' })
-      })
+      globalThis.fetch = mockFetchResponse({ unexpected: 'format' }, 500, 'Internal Server Error')
 
       await expect(get('https://api.example.com/test', {})).rejects.toThrow()
     })
@@ -96,7 +80,7 @@ describe('request utilities', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('POST')
       expect(calledOptions.body).toBe(JSON.stringify(body))
 
@@ -112,7 +96,7 @@ describe('request utilities', () => {
         params: { minDocCount: 1 }
       })
 
-      const calledUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      const calledUrl = (fetch as Mock<typeof fetch>).mock.calls[0][0]
       expect(calledUrl).toContain('minDocCount=1')
     })
   })
@@ -130,7 +114,7 @@ describe('request utilities', () => {
 
       expect(result).toEqual(responseData)
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('POST')
       expect(calledOptions.body).toBeInstanceOf(FormData)
     })
@@ -145,7 +129,7 @@ describe('request utilities', () => {
         params: { service: 'myService' }
       })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.method).toBe('DELETE')
     })
 
@@ -156,7 +140,7 @@ describe('request utilities', () => {
         headers: { Authorization: 'Bearer token' }
       }, ['sub1', 'sub2'])
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.body).toBe(JSON.stringify(['sub1', 'sub2']))
     })
 
@@ -167,7 +151,7 @@ describe('request utilities', () => {
         headers: { Authorization: 'Bearer token' }
       })
 
-      const calledOptions = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]
+      const calledOptions = (fetch as Mock<typeof fetch>).mock.calls[0][1]!
       expect(calledOptions.body).toBeUndefined()
     })
   })


### PR DESCRIPTION
## Summary
Enables `oxlint-tsgolint` (`options.typeAware: true` in `.oxlintrc.json`) and adds the 24 rules that `typescript-eslint`'s `recommendedTypeChecked` preset layers on top of `recommended` (`await-thenable`, `no-floating-promises`, `no-unsafe-*`, `require-await`, `restrict-template-expressions`, `unbound-method`, etc.) — the exact rule set, taken from `@typescript-eslint/eslint-plugin`'s `configs/flat/recommended-type-checked-only.js` rather than guessed.

**Depends on #104** (based on `chore/oxlint-migration`) — this diff only shows the type-aware rule additions; rebase/retarget once #104 (and #103) merge.

Runs correctly against `typescript@7.0.2` with no shim needed — worth noting this codebase's typescript-eslint/TS7 blocker (#101) never actually applied to these type-aware rules, since `eslint.config.mjs` only ever used the non-type-checked `recommended` preset.

## The findings were bigger than initially scoped, but mostly one pattern
First pass surfaced **160 findings** (not the ~50 estimated when this was scoped in #104's description) — almost all of it was one systemic pattern, not scattered real correctness issues:

- **`src/utils/request.ts`**'s `fetchJson()` typed its parsed response as implicit `any` (`Response.json()` returns `Promise<any>`), which then flowed untyped through `get`/`post`/`postForm`/`del` into every consumer (`docs.ts`, `filter.ts`, `notification.ts`, `story.ts`). Typed it `unknown` instead — every call site already validates through zod immediately, so this one-line fix resolved the entire `src/` side of the findings. `FilterCenter`'s methods, which don't validate their response, now correctly return `Promise<unknown>` instead of `Promise<any>` — a stricter, **correct public type change**, not a runtime behavior change (worth a mention since it's technically a public API type surface diff).
- `buildUrl`/`buildHeaders`/`buildForm` in `request.ts` took a bare `object` parameter, which made `Object.entries(...)` values `any`; narrowed to `Record<string, string | number>` / `Record<string, string>` / `AuthForm` to match how they're actually called.
- **`QueryBuilder.ts`**: nearley's `parser.results` is typed `any[]`; added an explicit `as Ast` cast with a comment, since the grammar guarantees the shape but nearley's generic types can't express that.
- The bulk (**146/160**) was test files: `(fetch as ReturnType<typeof vi.fn>).mock.calls[0][1]` erases all type information, since `vi.fn()` without a type argument defaults to `(...args: any[]) => any`. Five test files each rolled their own loosely-typed fetch mock (four near-identical, one slightly different for sequential responses) — consolidated into `tests/helpers/mockFetch.ts`, typed against `Mock<typeof fetch>`, so `.mock.calls[0][1]` is a real `RequestInit` instead of `any`. Fixed the resulting handful of `JSON.parse(...)`-returns-`any` sites in `docs.test.ts` by asserting the already-known `SearchRequest` shape.
- Two `searchSpy.mockImplementation(async () => {...})` in `docs.test.ts` never awaited anything (`require-await`) — dropped `async`, returning `Promise.resolve(...)` explicitly instead, since the mocked signature needs a Promise-returning implementation.
- One irreducible case: vitest's `expect.arrayContaining`/`objectContaining` asymmetric matchers are typed to return `any` by design (`tests/utils/QueryBuilder.test.ts`) — narrow inline disable with a comment, since there's no more specific type to assign there.

## Verification
- `npx oxlint .`: clean.
- Full `lint` + `build` + `test` (198/198) pass.
- `npm run verify:package` (publint + Are the Types Wrong): still no issues — confirms the `request.ts` return-type change didn't regress the published declarations.
- `pnpm install --frozen-lockfile` mirrors CI successfully.

## Test plan
- [x] `npm run lint` (oxlint, type-aware, 0 issues)
- [x] `npm run build`
- [x] `npm run verify:package`
- [x] `npm test` (198/198)
- [x] `pnpm install --frozen-lockfile` (mirrors CI)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>